### PR TITLE
chore: release 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-magic-toast",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A beautiful, imperative, toast you can call from anywhere!",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Cuts a release so the nth-check ReDoS fix from #3 reaches consumers. npm is still on 0.3.1.

## Why 0.4.0 and not 0.3.2

`react-native-svg` went 12 -> 15, and it's a hard dependency here, not a peer. Anyone pinning svg 12 can end up with a duplicate native module, so this isn't a silent patch. On 0.x that makes it a minor.

## What's in it
- #3: `react-native-svg` ^12.1.1 -> ^15.0.0, clears the high-severity nth-check ReDoS that reached consumers through css-select@4. `yarn audit --groups dependencies` is now clean.
- Same PR unrotted the test suite (babel couldn't resolve metro-react-native-babel-preset, magic-modal v4 peers weren't installed, snapshot was stale v3 output).

Version bump only on this branch.