### PR TITLE
chore(deps): force uuid to 11.1.1 in both lockfiles

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -25,6 +25,9 @@
     "react-native-web": "^0.21.0",
     "react-native-worklets": "~0.8.3"
   },
+  "resolutions": {
+    "uuid": "^11.1.1"
+  },
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/runtime": "^7.9.6",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4295,10 +4295,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+uuid@^11.1.1, uuid@^7.0.3:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 validate-npm-package-name@^5.0.0:
   version "5.0.1"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
-    "@types/react": "~19.2.14"
+    "@types/react": "~19.2.14",
+    "uuid": "^11.1.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8941,10 +8941,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+uuid@^11.1.1, uuid@^7.0.3:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
Forces uuid to 11.1.1 in both lockfiles. That clears two of the three open Dependabot alerts: the same advisory (GHSA-w5hq-g745-h8pq, missing buffer bounds check in v3/v5/v6) fires once against `yarn.lock` and once against `example/yarn.lock`.

Both lockfiles had exactly one uuid, 7.0.3, pulled in by `@expo/config-plugins@~55.0.11` -> `xcode@3.0.1`, which pins `uuid@^7.0.3`. xcode 3.0.1 is the latest stable release, everything past it is a nightly, so moving the parent forward isn't an option and a yarn resolution is the only way off 7.0.3. xcode's only use of uuid is `uuid.v4()` in pbxProject.js, and uuid 11 still ships that from its CJS build, so the call site is unaffected.

The diff is 4 lines per lockfile. uuid is the only package that moved.

## Why brace-expansion is still open

I couldn't clear the third one (GHSA-mh99-v99m-4gvg, high, `example/yarn.lock`) without breaking the example app, so I left it.

The advisory range is `<= 5.0.7` with no lower bound, and the only patched version is 5.0.8. The 5.x copy in `example/yarn.lock` is already on 5.0.8. What still matches the range is brace-expansion 1.1.16 and 2.1.2, and there's no patched 1.x or 2.x to move to. Closing the alert means forcing every copy to 5.0.8.

brace-expansion 5 dropped `module.exports = expand` for a named `expand` export. I tried the resolution in a scratch clone and it does collapse the tree to a single 5.0.8, at the cost of:

- minimatch 3.1.5 throws `TypeError: expand is not a function`
- minimatch 8.0.7 throws `TypeError: (0 , brace_expansion_1.default) is not a function`

Both only throw on patterns that contain braces. That's why `expo export` still passed when I tried it. `test-exclude` throws on construction, and `@react-native/codegen` globs `${filePattern}/**/*{,.fb}.{js,ts,tsx}` through glob@7 -> minimatch 3 on every native build.

minimatch 3 comes in from react-native 0.83.6 itself, plus rimraf@3 and test-exclude@6, so it can't be dropped without changing the pinned RN version.

## Verification

No CI on this repo, so all of this is local, from a clean clone with `node_modules` deleted and both trees reinstalled.

| | result |
|---|---|
| `yarn lint` | clean |
| `yarn typescript` | clean |
| `yarn test` | 1 suite, 2 tests, 2 snapshots passed |
| `yarn prepare` | 14 files -> commonjs, module, typescript |
| `expo export` (ios, android, web) | all three bundled, 0 errors |

I exported all three platforms before and after the bump and the bundle hashes come out byte-identical. Nothing was run on a device or simulator.

No tag and no publish, and `package.json` is untouched at 0.4.0.


https://claude.ai/code/session_015uj6xe9Bt2zFYmqU6UTTkQ
