### PR TITLE
ci: add a branch checkup workflow

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -1,0 +1,48 @@
+name: 🛠️ Branch Checkup
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checkup:
+    name: 👮‍♂️ Lint, Typecheck, Test and Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v7
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+
+      # `.yarnrc` points `yarn-path` at scripts/bootstrap.js, which forwards to
+      # yarn whenever arguments are passed and otherwise installs the example
+      # app and the pods too. Passing the flags keeps it to the library.
+      - name: 📦 Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: 🧹 Lint
+        run: yarn lint
+
+      - name: 🧪 Typecheck
+        run: yarn typescript
+
+      - name: 🧪 Test
+        run: yarn test
+
+      # `prepare` runs `bob build`, so the install above already built once.
+      # Running it again is what fails the job if the build breaks.
+      - name: 🛠️ Build
+        run: yarn prepare


### PR DESCRIPTION
Adds a branch checkup workflow. husky runs lint and typecheck on commit and commitlint on the message, but nothing runs on the server, so a PR from a fork or a commit made with `--no-verify` goes in unchecked.

Same shape as [magic-modal's branch checkup](https://github.com/GSTJ/react-native-magic-modal/blob/main/.github/workflows/branch-validation.yml), minus the pnpm, turbo and expo-doctor parts that don't apply here. Runs on PRs and on pushes to master: `yarn lint`, `yarn typescript`, `yarn test`, `yarn prepare`. That last one is `bob build`, so a broken build fails the job.

`.yarnrc` points `yarn-path` at `scripts/bootstrap.js`, which installs the example app and the pods when it's called with no arguments. Passing `install --frozen-lockfile` makes it forward to yarn and stay on the library.

Keeping the package. magic-toast lists magic-modal as a dependency and supplies the toast layer on top of it, so magic-modal reaching 7.1.0 doesn't replace it. magic-modal's public API is `MagicModalPortal`, `magicModal` and `useMagicModal`. magic-toast v1.0.0 shipped against magic-modal v7 with RN 0.83.6, React 19.2 and reanimated 4.3.1, and it pulled 286 downloads last month.

## Proof

![Branch checkup run, every step green](https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/refs/heads/gstj/pr-assets-dump/magic-toast-ci.png)

Locally, from an empty `node_modules` and `lib`:

![Local run: install, lint, typecheck, test, bob build, pack](https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/refs/heads/gstj/pr-assets-dump/magic-toast-local.png)
