### PR TITLE
ci: call the shared workflow by tag instead of @main

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -17,7 +17,7 @@ jobs:
   # Lint, format and typecheck come from the shared workflow in GSTJ/magic.
   # Node version is read from .nvmrc and pnpm from the `packageManager` field.
   checkup:
-    uses: GSTJ/magic/.github/workflows/ci.yml@main
+    uses: GSTJ/magic/.github/workflows/ci.yml@v1
     with:
       # `pnpm install` already runs `prepare`, which is `bob build`. Running it
       # again is what fails the job if the build breaks.


### PR DESCRIPTION
Switches `.github/workflows/branch-validation.yml` from `GSTJ/magic/.github/workflows/ci.yml@main` to `@v1`.

`@main` means an unreviewed merge in GSTJ/magic reruns this repo's CI against whatever landed five minutes ago. `@v1` is the moving major tag (currently v1.4.0), so fixes still arrive on the next run.

The three inputs this repo passes — `build-command`, `test-command`, `turbo-cache` — all exist in `ci.yml`'s `workflow_call` signature at v1, so nothing else in the call changes.

No dependency changes: `magic-oxlint-config`, `magic-oxfmt-config`, `magic-tsconfig` are already at 1.2.0 and `magic-codemods` at 1.1.0, which are the current latest. `magic-oxlint-plugin` is not used here (no opt-in rules for this repo), so no new quarantine exclusions were needed — the existing `minimumReleaseAgeExclude` entries are all still inside the 24h window and stay.

Verified locally: `pnpm install --frozen-lockfile` clean, oxlint 0 diagnostics over 21 files, `oxfmt --check` clean, `tsc --noEmit` clean, jest 2/2 passing, `bob build` succeeds.