### PR TITLE
fix(changelog): write CHANGELOG.md and backfill the history

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -23,5 +23,10 @@ jobs:
       # again is what fails the job if the build breaks.
       build-command: pnpm run build
       test-command: pnpm test
+      # tools/changelog-preset.mjs decides which commit types reach
+      # CHANGELOG.md, and getting it wrong drops commits with no error
+      # anywhere. This renders a synthetic history through it and fails if a
+      # breaking change goes missing — including one hanging off a hidden type.
+      extra-command: pnpm run changelog:check
       # No turbo in this repo.
       turbo-cache: false

--- a/.release-it.mjs
+++ b/.release-it.mjs
@@ -1,0 +1,58 @@
+// Moved out of package.json so the changelog policy can live in one place.
+// tools/changelog-preset.mjs owns the type list; this file and
+// tools/changelog-check.mjs both read it, so the check can't pass against a
+// list the release doesn't use.
+import { TYPES } from "./tools/changelog-preset.mjs";
+
+// The preamble at the top of CHANGELOG.md. The plugin strips this exact string
+// out of the existing file before prepending the new section, so anything you
+// want to stay above the newest release has to be in here rather than typed
+// into CHANGELOG.md by hand — text in the file that isn't in this string gets
+// pushed underneath the next release.
+const header = `# Changelog
+
+Generated from conventional commit messages. Breaking changes get their own
+heading, from either a \`!\` after the type or a \`BREAKING CHANGE:\` footer.
+
+Everything at 1.0.0 and below was backfilled from git history after the fact.
+Releases up to 0.3.1 were published with empty notes; the sections here are what
+the commits in each range actually say, which for 0.2.2 and 0.3.1 includes
+breaking changes that never made it into the published release bodies. The tags
+themselves were left alone.`;
+
+const config = {
+  plugins: {
+    "@release-it/conventional-changelog": {
+      // Without this the changelog was generated for the release body and
+      // thrown away — nine releases and no CHANGELOG.md in the repo. The plugin
+      // prepends, so everything already in the file stays exactly as it is.
+      infile: "CHANGELOG.md",
+      header,
+      preset: {
+        name: "conventionalcommits",
+        types: TYPES,
+      },
+    },
+  },
+  git: {
+    commitMessage: "chore: release ${version}",
+    tagName: "v${version}",
+    // Annotate the tag with the same section the changelog and the GitHub
+    // release get. `git show v1.0.1` then tells you what shipped instead of
+    // "Release 1.0.1", and the three places a reader might look can't disagree.
+    tagAnnotation: "${changelog}",
+    // git's default tag cleanup is `strip`, which deletes every line starting
+    // with `#` — that is every `### Bug Fixes` heading and the `## [1.0.1]`
+    // title, leaving a tag message of unlabelled bullets. Measured on a
+    // rehearsal, not assumed.
+    tagArgs: ["--cleanup=verbatim"],
+  },
+  npm: {
+    publish: true,
+  },
+  github: {
+    release: true,
+  },
+};
+
+export default config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog
+
+Generated from conventional commit messages. Breaking changes get their own
+heading, from either a `!` after the type or a `BREAKING CHANGE:` footer.
+
+Everything at 1.0.0 and below was backfilled from git history after the fact.
+Releases up to 0.3.1 were published with empty notes; the sections here are what
+the commits in each range actually say, which for 0.2.2 and 0.3.1 includes
+breaking changes that never made it into the published release bodies. The tags
+themselves were left alone.
+
+## [1.0.0](https://github.com/GSTJ/react-native-magic-toast/compare/v0.4.0...v1.0.0) (2026-07-26)
+
+The toast API itself is unchanged. The break is `react-native-magic-modal`
+going 4 -> 7 underneath, which drags the peer floor up with it. The
+[v1.0.0 release notes](https://github.com/GSTJ/react-native-magic-toast/releases/tag/v1.0.0)
+carry the upgrade guide: the peer version table, the new-architecture and
+Reanimated 4 Babel plugin steps, and the return-value shape change on
+`magicToast.show()`.
+
+### ⚠ BREAKING CHANGES
+
+* requires react-native-magic-modal v7, react-native >= 0.81,
+  react-native-reanimated >= 4, react-native-gesture-handler >= 2.20 and
+  react-native-worklets >= 0.5. Apps that can't move yet should stay on 0.4.x.
+
+### Features
+
+* move to react-native-magic-modal v7 ([#5](https://github.com/GSTJ/react-native-magic-toast/issues/5)) ([e42c0ac](https://github.com/GSTJ/react-native-magic-toast/commit/e42c0ac3d46911350da99614167e2d9e0c534816))
+
+### Chores
+
+* **deps:** force uuid to 11.1.1 in both lockfiles ([#7](https://github.com/GSTJ/react-native-magic-toast/issues/7)) ([7e44f77](https://github.com/GSTJ/react-native-magic-toast/commit/7e44f779ae3f896e54cc920dfb474b9066375745))
+* **deps:** refresh dev tooling ([#6](https://github.com/GSTJ/react-native-magic-toast/issues/6)) ([961dfde](https://github.com/GSTJ/react-native-magic-toast/commit/961dfde3b1aa6d86bc7cd346d372e0adbde3b4a2))
+* release 1.0.0 ([d91f79f](https://github.com/GSTJ/react-native-magic-toast/commit/d91f79f1d9582f3b1aff1b537cbbd3c9866781af))
+
+## [0.4.0](https://github.com/GSTJ/react-native-magic-toast/compare/v0.3.1...v0.4.0) (2026-07-25)
+
+A minor rather than a patch because `react-native-svg` is a hard dependency
+here, not a peer, so the ^12.1.1 -> ^15.0.0 move can leave an app pinning svg 12
+with a duplicate native module. See the
+[v0.4.0 release notes](https://github.com/GSTJ/react-native-magic-toast/releases/tag/v0.4.0).
+
+### Bug Fixes
+
+* **deps:** bump react-native-svg past the nth-check ReDoS ([#3](https://github.com/GSTJ/react-native-magic-toast/issues/3)) ([c33e89f](https://github.com/GSTJ/react-native-magic-toast/commit/c33e89f6629af0f11343ac21e768d8274ada7596))
+
+### Chores
+
+* release 0.4.0 ([#4](https://github.com/GSTJ/react-native-magic-toast/issues/4)) ([485269d](https://github.com/GSTJ/react-native-magic-toast/commit/485269d128d96773b25ad12b8031ec117386552c))
+
+## [0.3.1](https://github.com/GSTJ/react-native-magic-toast/compare/v0.2.2...v0.3.1) (2024-06-08)
+
+### ⚠ BREAKING CHANGES
+
+* use magic modal v4
+
+### Features
+
+* use magic modal v4 ([7a90e18](https://github.com/GSTJ/react-native-magic-toast/commit/7a90e18c8325323b21c0e27460617dc3f2089683))
+
+### Chores
+
+* release 0.3.1 ([a5bd063](https://github.com/GSTJ/react-native-magic-toast/commit/a5bd0630af16acadea7dd0949b7a29a8ba9e31cd))
+
+## [0.2.2](https://github.com/GSTJ/react-native-magic-toast/compare/v0.2.1...v0.2.2) (2024-05-26)
+
+### ⚠ BREAKING CHANGES
+
+* support new react-native-magic-modal version
+
+### Features
+
+* support new react-native-magic-modal version ([4ddcd52](https://github.com/GSTJ/react-native-magic-toast/commit/4ddcd5202e0087faa7a0aa6a6799ff4e46f02ea7))
+
+### Chores
+
+* release 0.2.2 ([3b80f3f](https://github.com/GSTJ/react-native-magic-toast/commit/3b80f3f639b33019fab0d07d85e7059d458d2401))
+
+## [0.2.1](https://github.com/GSTJ/react-native-magic-toast/compare/v0.2.0...v0.2.1) (2023-08-21)
+
+### Bug Fixes
+
+* typescript bindings ([3bf9e1c](https://github.com/GSTJ/react-native-magic-toast/commit/3bf9e1c112b8d1c7a85216d5236a28f939b09053))
+
+### Chores
+
+* release 0.2.1 ([c58904d](https://github.com/GSTJ/react-native-magic-toast/commit/c58904da56aa68a08ebf9c1e3ebd2213fab93f1d))
+
+## [0.2.0](https://github.com/GSTJ/react-native-magic-toast/compare/v0.1.3...v0.2.0) (2023-08-21)
+
+### Features
+
+* add custom 'show' toast and a success toast ([2b9613a](https://github.com/GSTJ/react-native-magic-toast/commit/2b9613a0ee1eb85a419826c92b122f142d4dab92))
+* add custom success icon ([807afeb](https://github.com/GSTJ/react-native-magic-toast/commit/807afebdd34bd99fe3a0897021ffabf7a4065d92))
+* improve success toast style ([73bb0c5](https://github.com/GSTJ/react-native-magic-toast/commit/73bb0c505590333fba4a90a2a5bd63bc25f3c1fb))
+* upgrade expo version on examples ([b4a3f7e](https://github.com/GSTJ/react-native-magic-toast/commit/b4a3f7e10313a3bd9be0427e1906f65a18a1d462))
+
+### Chores
+
+* release 0.2.0 ([bd37ccb](https://github.com/GSTJ/react-native-magic-toast/commit/bd37ccb6ed97400491f59d3ce22a198c1e69f50d))
+
+### Documentation
+
+* update readme.md ([760d8ce](https://github.com/GSTJ/react-native-magic-toast/commit/760d8ce0b6a8233534abfeffbe6bdbb40e2ba9d2))
+* update readme.md ([63eb743](https://github.com/GSTJ/react-native-magic-toast/commit/63eb7439de44ebdd1000e036fdf8749e0d3e963b))
+* update README.md ([48a59a2](https://github.com/GSTJ/react-native-magic-toast/commit/48a59a29c3218b838a36e93ec7ac25a2956576f2))
+
+## [0.1.3](https://github.com/GSTJ/react-native-magic-toast/compare/v0.1.2...v0.1.3) (2022-02-22)
+
+### Chores
+
+* release 0.1.3 ([51ec837](https://github.com/GSTJ/react-native-magic-toast/commit/51ec837c2a123d3f3544db2acd98f03125c999f4))
+
+### Documentation
+
+* update usage and installation instructions ([fba8be0](https://github.com/GSTJ/react-native-magic-toast/commit/fba8be061693081a1aa763728bd161d3cc0fc3f6))
+
+## [0.1.2](https://github.com/GSTJ/react-native-magic-toast/compare/v0.1.1...v0.1.2) (2022-02-22)
+
+### Chores
+
+* release 0.1.2 ([ad72c89](https://github.com/GSTJ/react-native-magic-toast/commit/ad72c89c1bcebd9d1786d88e27cf5853d63f11d8))
+
+### Documentation
+
+* update usage and installation instructions ([36d3691](https://github.com/GSTJ/react-native-magic-toast/commit/36d369139f933205d79a61f60ce337ccbed2adbf))
+
+## [0.1.1](https://github.com/GSTJ/react-native-magic-toast/compare/1ee5edb20cc93e99806b840a54b6aee6c7902d1b...v0.1.1) (2022-02-22)
+
+### Chores
+
+* initial commit ([91fcb9c](https://github.com/GSTJ/react-native-magic-toast/commit/91fcb9ccccedc288f4e5ef26007e063fd70c74be))
+* initial commit ([1ee5edb](https://github.com/GSTJ/react-native-magic-toast/commit/1ee5edb20cc93e99806b840a54b6aee6c7902d1b))
+* release 0.1.1 ([160b1cd](https://github.com/GSTJ/react-native-magic-toast/commit/160b1cd82309c8007ac5b57fb9d180bc3d701ad7))
+
+### Documentation
+
+* update readme.md ([abd73e6](https://github.com/GSTJ/react-native-magic-toast/commit/abd73e6f582193778a3af84306f907f52cbe7789))

--- a/oxlint.config.mts
+++ b/oxlint.config.mts
@@ -9,4 +9,21 @@ import reactNative from "magic-oxlint-config/react-native";
 export default extendConfig(reactNative, {
   // react-native-builder-bob's output directory, so it only applies here.
   ignorePatterns: ["**/lib/**"],
+  overrides: [
+    {
+      // tools/ holds the changelog CLI. Printing to the terminal is what it is
+      // for — the CI job reads its output.
+      files: ["tools/**"],
+      rules: { "no-console": "off" },
+    },
+    {
+      // release-it's own config. `${version}` and `${changelog}` are release-it
+      // placeholders, resolved by its `format()` at release time, so they have
+      // to reach it as literal text rather than as template literals.
+      files: [".release-it.mjs"],
+      rules: {
+        "no-template-curly-in-string": "off",
+      },
+    },
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "build": "bob build",
+    "changelog:check": "node tools/changelog-check.mjs",
     "example": "pnpm --filter react-native-magic-toast-example",
     "format": "oxfmt --check .",
     "format:fix": "oxfmt .",
@@ -63,6 +64,9 @@
     "@types/react": "~19.2.14",
     "babel-preset-expo": "^55.0.24",
     "commitlint": "^21.2.1",
+    "conventional-changelog": "^8.1.0",
+    "conventional-changelog-conventionalcommits": "^10.2.1",
+    "conventional-recommended-bump": "^12.1.0",
     "expo": "^55.0.28",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
@@ -145,22 +149,5 @@
         }
       ]
     ]
-  },
-  "release-it": {
-    "git": {
-      "commitMessage": "chore: release ${version}",
-      "tagName": "v${version}"
-    },
-    "npm": {
-      "publish": true
-    },
-    "github": {
-      "release": true
-    },
-    "plugins": {
-      "@release-it/conventional-changelog": {
-        "preset": "angular"
-      }
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,15 @@ importers:
       commitlint:
         specifier: ^21.2.1
         version: 21.2.1(@types/node@26.1.1)(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(typescript@5.9.3)
+      conventional-changelog:
+        specifier: ^8.1.0
+        version: 8.1.0(conventional-commits-filter@6.0.1)
+      conventional-changelog-conventionalcommits:
+        specifier: ^10.2.1
+        version: 10.2.1
+      conventional-recommended-bump:
+        specifier: ^12.1.0
+        version: 12.1.0
       expo:
         specifier: ^55.0.28
         version: 55.0.28(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)

--- a/tools/changelog-check.mjs
+++ b/tools/changelog-check.mjs
@@ -1,0 +1,332 @@
+// Control for tools/changelog-preset.mjs.
+//
+// The preset decides which commit types reach the changelog and which of them
+// can move the version, so the risk it carries is silent omission: mark a type
+// hidden and its commits vanish with no error anywhere. A breaking change
+// vanishing that way is the one failure this package cannot ship.
+//
+// POLICY below is written out longhand on purpose. Deriving it from the
+// preset's own type list would make every assertion a tautology — hide a
+// section and the check would just change its mind about what it expected. So
+// the policy is stated here, the preset is asserted to match it, and the
+// rendered output is asserted to match it too. Changing what reaches the
+// changelog means changing both files, deliberately.
+//
+// Three things get checked:
+//
+//   1. the type list agrees with the policy
+//   2. a synthetic history of every type renders the way the policy says,
+//      including the `ci!:` case — `ci` is hidden and its breaking note still
+//      has to surface
+//   3. the recommended bump respects `effect`, so a release of nothing but
+//      `build:` and `chore:` commits cannot come out a minor
+//
+// Then it renders the same history through a sabotaged type list and fails if
+// *that* passes. An assertion that cannot fail is worth nothing.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Bumper } from "conventional-recommended-bump";
+
+import preset, { TYPES } from "./changelog-preset.mjs";
+
+const here = import.meta.dirname;
+const presetPath = join(here, "changelog-preset.mjs");
+// Resolved rather than assumed to sit at ../node_modules/.bin: pnpm hoists, and
+// in a workspace the binary can land in the root store instead of the package.
+// The package exports no `./package.json`, so resolve its entry point and walk
+// across to the CLI beside it.
+const cliEntry = fileURLToPath(import.meta.resolve("conventional-changelog"));
+const cliPath = join(dirname(cliEntry), "cli", "index.js");
+
+/**
+ * What each type is for. `bump` can raise the version, `changelog` renders
+ * without raising it, `hidden` does neither.
+ *
+ * @type {Record<string, "bump" | "changelog" | "hidden">}
+ */
+const POLICY = {
+  feat: "bump",
+  feature: "bump",
+  fix: "bump",
+  perf: "bump",
+  revert: "bump",
+  build: "changelog",
+  refactor: "changelog",
+  chore: "changelog",
+  docs: "changelog",
+  ci: "hidden",
+  style: "hidden",
+  test: "hidden",
+};
+
+// One commit per type, plus three breaking ones spread across a bump type, a
+// changelog type and a hidden type.
+const COMMITS = [
+  "feat: add a thing",
+  "fix: correct a thing",
+  "build: shrink the tarball",
+  "refactor: rewrite the internals",
+  "chore(deps): bump something",
+  "docs: update the readme",
+  "ci: tweak the workflow",
+  "style: reformat",
+  "test: add cases",
+  "perf!: drop the slow path\n\nBREAKING CHANGE: the slow path is gone",
+  "chore: retire the legacy loader\n\nBREAKING CHANGE: the legacy loader is gone",
+  "ci!: require node 24\n\nBREAKING CHANGE: node 22 is no longer supported",
+];
+
+// Subject fragment -> the type it was committed under. Matching on subjects
+// rather than section headings keeps the check working in a repo that renames
+// its sections.
+const SUBJECTS = {
+  feat: "add a thing",
+  fix: "correct a thing",
+  build: "shrink the tarball",
+  refactor: "rewrite the internals",
+  chore: "bump something",
+  docs: "update the readme",
+  ci: "tweak the workflow",
+  style: "reformat",
+  test: "add cases",
+};
+
+const NOTES = {
+  "a bump type (perf!)": "the slow path is gone",
+  "a changelog type (chore!)": "the legacy loader is gone",
+  "a HIDDEN type (ci!)": "node 22 is no longer supported",
+};
+
+/**
+ * Builds a throwaway repo out of `commits` and hands it to `run`. Async on
+ * purpose: `bumpFor` below is, and a synchronous `finally` would delete the
+ * repo out from under it.
+ *
+ * `tag` says where v1.0.0 goes, and the two callers need different answers.
+ * The renderer wants it last, so `--release-count 0` has a released section to
+ * render — a chunk whose version matches the last tag comes out empty. The
+ * bumper wants it first, so the commits are the range being measured.
+ *
+ * @template T
+ * @param {string[]} commits
+ * @param {"before" | "after"} tag
+ * @param {(repo: string) => T | Promise<T>} run
+ * @returns {Promise<T>}
+ */
+const inThrowawayRepo = async (commits, tag, run) => {
+  const repo = mkdtempSync(join(tmpdir(), "magic-toast-changelog-"));
+  /** @param {string[]} args */
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: repo, encoding: "utf8", stdio: "pipe" });
+
+  try {
+    git("init", "--quiet", "--initial-branch", "main");
+    git("config", "user.email", "check@example.com");
+    git("config", "user.name", "changelog check");
+    writeFileSync(
+      join(repo, "package.json"),
+      JSON.stringify({ name: "changelog-check", version: "1.0.0" }),
+    );
+    git("add", ".");
+    git("commit", "--quiet", "-m", "chore: initial");
+    if (tag === "before") git("tag", "-a", "v1.0.0", "-m", "v1.0.0");
+
+    for (const message of commits) {
+      git(
+        "commit",
+        "--quiet",
+        "--allow-empty",
+        "--cleanup=verbatim",
+        "-m",
+        message,
+      );
+    }
+
+    if (tag === "after") git("tag", "-a", "v1.0.0", "-m", "v1.0.0");
+
+    return await run(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+};
+
+/**
+ * Renders COMMITS through a preset module and returns the changelog text.
+ *
+ * @param {string} configPath
+ * @returns {Promise<string>}
+ */
+const render = (configPath) =>
+  inThrowawayRepo(COMMITS, "after", (repo) =>
+    execFileSync(
+      process.execPath,
+      [cliPath, "--config", configPath, "--release-count", "0", "--stdout"],
+      { cwd: repo, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+    ),
+  );
+
+/**
+ * The release type conventional-recommended-bump lands on for `commits`, read
+ * through the real preset. `null` means "nothing here warrants a release".
+ *
+ * @param {string[]} commits
+ * @returns {Promise<string | null>}
+ */
+const bumpFor = (commits) =>
+  inThrowawayRepo(commits, "before", async (repo) => {
+    const bumper = new Bumper(repo);
+    bumper.loadPreset({ name: "conventionalcommits", types: TYPES });
+    // Same double cast .release-it.js needs: the preset publishes
+    // `createPreset(config?): {}`, so its own return type doesn't describe the
+    // `whatBump` it demonstrably returns. `bump()` is typed as a union whose
+    // empty arm has no `releaseType`, which is the `null` case here.
+    const { whatBump } =
+      /** @type {{ whatBump: Parameters<Bumper["bump"]>[0] }} */ (
+        /** @type {unknown} */ (await preset)
+      );
+    const recommendation = /** @type {{ releaseType?: string }} */ (
+      await bumper.bump(whatBump)
+    );
+    return recommendation.releaseType ?? null;
+  });
+
+/** @type {string[]} */
+const failures = [];
+/**
+ * @param {string} label
+ * @param {boolean} condition
+ */
+const expect = (label, condition) => {
+  if (!condition) failures.push(label);
+};
+
+// 1. The type list says what the policy says.
+for (const [type, effect] of Object.entries(POLICY)) {
+  const entry = TYPES.find((candidate) => candidate.type === type);
+  expect(`${type} is in the type list`, entry !== undefined);
+  expect(`${type} is "${effect}"`, entry?.effect === effect);
+}
+for (const entry of TYPES) {
+  expect(`${entry.type} is covered by the policy`, entry.type in POLICY);
+}
+
+/**
+ * 2. The rendered output says what the policy says.
+ *
+ * @param {string} output
+ * @returns {string[]}
+ */
+const assessRendering = (output) => {
+  /** @type {string[]} */
+  const found = [];
+  /**
+   * @param {string} label
+   * @param {boolean} condition
+   */
+  const check = (label, condition) => {
+    if (!condition) found.push(label);
+  };
+
+  // Breaking changes render whatever type they hang off, hidden ones included.
+  // The preset prefixes the heading with a warning sign, so match on the words.
+  check("BREAKING CHANGES heading", /^### .*BREAKING CHANGES$/m.test(output));
+  for (const [label, text] of Object.entries(NOTES)) {
+    check(`breaking note on ${label}`, output.includes(text));
+  }
+
+  for (const [type, subject] of Object.entries(SUBJECTS)) {
+    const shouldRender = POLICY[type] !== "hidden";
+    check(
+      shouldRender ? `${type} renders` : `${type} stays hidden`,
+      output.includes(subject) === shouldRender,
+    );
+  }
+
+  return found;
+};
+
+failures.push(...assessRendering(await render(presetPath)));
+
+// 3. `effect` decides the bump, not just the rendering. The middle case is the
+// one that matters: those four types all render, and none of them may push a
+// release past a patch.
+const bumps = {
+  breaking: await bumpFor(["feat!: drop the old API"]),
+  feature: await bumpFor(["feat: add a thing"]),
+  fix: await bumpFor(["fix: correct a thing"]),
+  changelogOnly: await bumpFor([
+    "build: shrink the tarball",
+    "refactor: rewrite the internals",
+    "chore(deps): bump something",
+    "docs: update the readme",
+  ]),
+  hiddenOnly: await bumpFor(["ci: tweak the workflow", "style: reformat"]),
+};
+
+expect("a breaking feat is a major", bumps.breaking === "major");
+expect("a feat is a minor", bumps.feature === "minor");
+expect("a fix is a patch", bumps.fix === "patch");
+expect(
+  `build/refactor/chore/docs alone do not bump (got ${bumps.changelogOnly})`,
+  bumps.changelogOnly === null,
+);
+expect(
+  `ci/style alone do not bump (got ${bumps.hiddenOnly})`,
+  bumps.hiddenOnly === null,
+);
+
+if (failures.length > 0) {
+  console.error("changelog preset check FAILED:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+// Negative control. Same commits, same assertions, a type list with every
+// visible type forced to `hidden`. POLICY doesn't move, so hiding a section has
+// to show up as a failure.
+const sabotaged = TYPES.map((entry) =>
+  entry.effect === "hidden" ? entry : { ...entry, effect: "hidden" },
+);
+// Written next to the real preset rather than in the temp dir so the bare
+// `conventional-changelog-conventionalcommits` specifier still resolves.
+const sabotagedPath = join(
+  here,
+  `.changelog-preset-sabotaged.${process.pid}.mjs`,
+);
+writeFileSync(
+  sabotagedPath,
+  'import createPreset from "conventional-changelog-conventionalcommits";\n' +
+    `export default createPreset({ types: ${JSON.stringify(sabotaged)} });\n`,
+);
+
+let sabotagedFailures;
+try {
+  sabotagedFailures = assessRendering(await render(sabotagedPath));
+} finally {
+  rmSync(sabotagedPath, { force: true });
+}
+
+if (sabotagedFailures.length === 0) {
+  console.error(
+    "negative control FAILED: hiding every visible type changed nothing, so the assertions above are not testing anything.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `changelog preset check passed (${COMMITS.length} synthetic commits, 3 breaking; bumps: feat!=${bumps.breaking}, feat=${bumps.feature}, fix=${bumps.fix}, changelog-only=${bumps.changelogOnly}, hidden-only=${bumps.hiddenOnly})`,
+);
+console.log(
+  `negative control passed (hiding the visible types breaks ${sabotagedFailures.length} assertions: ${sabotagedFailures.join(", ")})`,
+);
+
+// `--print` is for looking at the control by hand, which is the only way to
+// judge the section names and ordering. The assertions above cannot.
+if (process.argv.includes("--print")) {
+  console.log("\n--- rendered through the real preset ---\n");
+  console.log(await render(presetPath));
+}

--- a/tools/changelog-preset.mjs
+++ b/tools/changelog-preset.mjs
@@ -1,0 +1,52 @@
+// conventionalcommits preset, retuned so the changelog lists what actually
+// ships.
+//
+// The stock preset renders feat, fix, perf and reverts and hides everything
+// else, which is wrong for a package whose `files` field publishes `src/` and
+// `lib/` side by side. A `refactor:` here rewrites both. A `chore(deps):` moves
+// the dependency tree a consumer installs. Hiding those leaves releases that
+// changed the tarball described by an empty section.
+//
+// The split is by whether a type can change what npm hands a consumer:
+//
+//   renders   feat fix perf revert   the stock set
+//             build                  bob's targets and tsconfig.build.json
+//                                    decide what lands in lib/
+//             refactor               rewrites src/ and lib/, both published
+//             chore                  dependency and config moves ship
+//             docs                   README.md is inside the tarball
+//
+//   hidden    ci                     .github/ is not in `files`
+//             style                  oxfmt does touch published src/, but only
+//                                    its whitespace — nothing a consumer can
+//                                    observe at runtime or in types
+//             test                   `!**/__tests__` is excluded from `files`
+//
+// `effect: "changelog"` is the important part: it renders the type without
+// letting it drive the version bump, so a pile of `build:` commits still adds
+// up to a patch. Only the `bump` types can raise that, exactly as before.
+//
+// Breaking changes are not configurable here and do not need to be. The
+// preset's writer sets `discard = false` the moment a commit carries a note, so
+// a `BREAKING CHANGE:` footer or a `!` renders its own section whatever type it
+// hangs off, including the hidden ones. tools/changelog-check.mjs is the
+// positive control for that.
+import createPreset from "conventional-changelog-conventionalcommits";
+
+/** @type {import("conventional-changelog-conventionalcommits").CommitType[]} */
+export const TYPES = [
+  { type: "feat", section: "Features", effect: "bump" },
+  { type: "feature", section: "Features", effect: "bump" },
+  { type: "fix", section: "Bug Fixes", effect: "bump" },
+  { type: "perf", section: "Performance Improvements", effect: "bump" },
+  { type: "revert", section: "Reverts", effect: "bump" },
+  { type: "build", section: "Build System", effect: "changelog" },
+  { type: "refactor", section: "Code Refactoring", effect: "changelog" },
+  { type: "chore", section: "Chores", effect: "changelog" },
+  { type: "docs", section: "Documentation", effect: "changelog" },
+  { type: "ci", section: "Continuous Integration", effect: "hidden" },
+  { type: "style", section: "Styles", effect: "hidden" },
+  { type: "test", section: "Tests", effect: "hidden" },
+];
+
+export default createPreset({ types: TYPES });


### PR DESCRIPTION
This repo has shipped 9 releases and has no CHANGELOG.md. release-it's conventional-changelog plugin had no `infile`, so it generated a changelog for each release body and threw it away. Two of those bodies came out empty while the range under them contained a breaking change.

## Infile

`infile: "CHANGELOG.md"` plus a backfill of the 9 existing releases, generated from the commits. The plugin prepends, so once the file exists the history below the newest section is never rewritten.

The config moves from the `release-it` key in package.json to `.release-it.mjs`, because the type list now lives in `tools/changelog-preset.mjs` and JSON can't import it. `tools/changelog-check.mjs` reads the same list.

## Sections

`files` publishes `src` and `lib` side by side, so the split is whether a type can change what npm hands a consumer:

| renders | why |
| --- | --- |
| feat, fix, perf, revert | the stock set |
| build | bob's targets and tsconfig.build.json decide what lands in `lib/` |
| refactor | rewrites `src/` and `lib/`, both published |
| chore | dependency and config moves ship |
| docs | README.md is inside the tarball |

| hidden | why |
| --- | --- |
| ci | `.github/` is not in `files` |
| style | oxfmt touches published `src/`, whitespace only |
| test | `!**/__tests__` is excluded from `files` |

The four new ones are `effect: "changelog"`. They render without entering the bump count, so a release of nothing but `build:` commits is still a patch. Only `feat`, `fix`, `perf` and `revert` can raise a version.

## Backfill

Where the git history and a published release body disagree, the file follows the history.

0.2.2 and 0.3.1 each shipped a `feat!:` and each published a body with no sections at all. 0.2.2 went out as a patch off a breaking change. Both now carry their `⚠ BREAKING CHANGES` heading. No tag was moved and no release body was edited.

0.4.0 and 1.0.0 were written by hand and say more than the commits do (the peer version table, the new-architecture steps, the return-value change on `magicToast.show()`). Their generated sections carry a link to the release notes.

![Backfilled changelog vs the published bodies](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-changelog-backfill/react-native-magic-toast/changelog/toast-changelog.png)

## Check

`pnpm run changelog:check` builds a throwaway repo with 12 commits, one per type, 3 of them breaking, renders it through the real preset and asserts on what comes back. `ci` is hidden and the `ci!:` commit's breaking note still has to surface.

The check carries its own copy of the policy, so the two disagreeing is a failure. Derived from the preset, every assertion would be a tautology: hide a section and the check quietly redefines what it expected. The negative control in the image is what that failure looks like.

The bump is asserted too: `feat!` major, `feat` minor, `fix` patch, and build/refactor/chore/docs together no release at all.

Wired into Branch Checkup as `extra-command`.

![Preset check with its negative control](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-changelog-backfill/react-native-magic-toast/changelog/toast-controls.png)

## Release

npm `latest` is 1.0.0 and the 16 commits since the tag are tooling. Verified by rehearsing on a throwaway clone with publish, push and the GitHub release all off: 1.0.0 -> 1.0.1, the new section prepends, and `git diff` shows zero lines removed from everything below it.

The annotated tag now carries the same section as the changelog and the release body. git's default tag cleanup strips every line starting with `#`. That was eating all the headings. `tagArgs` pins `--cleanup=verbatim`.

![Release rehearsal](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-changelog-backfill/react-native-magic-toast/changelog/toast-rehearsal.png)
