### PR TITLE
fix(example): fire the first toast below MagicModalPortal

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ export default function App() {
 
 Then, you are free to use the magicToast as shown from anywhere you want.
 
+One ordering rule: `SafeAreaProvider` renders `null` until it has measured its
+insets, so `MagicModalPortal` is not mounted during the first commit. Calling
+`magicToast` from the mount effect of the component that renders the provider
+throws `MagicModalPortal not found`. Call it from a component below the portal,
+or pass `initialMetrics={initialWindowMetrics}` to the provider, which covers
+iOS and Android but not web.
+
 ```js
 import { magicToast } from "react-native-magic-toast";
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -10,34 +10,46 @@ const colors = {
   buttonText: "#ffffff",
 };
 
-const App = () => {
+/**
+ * The demo screen, rendered below `MagicModalPortal` so the portal is mounted
+ * by the time this component's effect runs.
+ *
+ * Firing the first toast from the component that renders `SafeAreaProvider`
+ * does not work. The provider renders `null` until it has its insets, so
+ * `MagicModalPortal` has not mounted yet and `magicModal.show` throws
+ * "MagicModalPortal not found". `initialMetrics` covers that on iOS and
+ * Android and does nothing on web, where `initialWindowMetrics` is null.
+ */
+const Demo = () => {
   React.useEffect(() => {
     magicToast.success("It works!!");
   }, []);
 
   return (
-    <SafeAreaProvider>
-      <MagicModalPortal />
-      <View style={styles.container}>
-        <TouchableOpacity
-          style={styles.button}
-          onPress={() => magicToast.alert("Oops! Something went wrong 😬")}
-        >
-          <Text style={styles.buttonText}>Press me to fire an alert!</Text>
-        </TouchableOpacity>
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => magicToast.alert("Oops! Something went wrong 😬")}
+      >
+        <Text style={styles.buttonText}>Press me to fire an alert!</Text>
+      </TouchableOpacity>
 
-        <TouchableOpacity
-          style={styles.button}
-          onPress={() => magicToast.success("Hurray! It works 🎉")}
-        >
-          <Text style={styles.buttonText}>
-            Press me to fire a success toast!
-          </Text>
-        </TouchableOpacity>
-      </View>
-    </SafeAreaProvider>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => magicToast.success("Hurray! It works 🎉")}
+      >
+        <Text style={styles.buttonText}>Press me to fire a success toast!</Text>
+      </TouchableOpacity>
+    </View>
   );
 };
+
+const App = () => (
+  <SafeAreaProvider>
+    <MagicModalPortal />
+    <Demo />
+  </SafeAreaProvider>
+);
 
 export default App;
 


### PR DESCRIPTION
The example app crashes on launch and comes up blank. It's been doing that since before v1.0.0.

`App` renders `SafeAreaProvider`, and the provider renders `null` until it has measured its insets:

```js
insets != null ? <SafeAreaInsetsContext.Provider value={insets}>{children}</...> : null
```

So `MagicModalPortal` isn't mounted during the first commit, `App`'s own mount effect runs anyway, and `magicModal.show` hits a null ref. React catches it at the root and the whole tree unmounts.

![console before and after](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-2026-07-28/magic-toast/2026-07-28/example-console.png)

`initialMetrics={initialWindowMetrics}` covers iOS and Android, where the native module fills those in at import time. On web `initialWindowMetrics` is null and the app still crashes with it, so that isn't the fix here.

Moving the demo screen into its own component below the portal covers all three platforms. The portal's `useImperativeHandle` is a layout effect, so it's already run by the time a sibling's passive effect fires.

The README gained the ordering rule. Its setup snippet was already correct and the constraint behind it was written down nowhere, which is how the example ended up calling `magicToast` before the portal existed.

## Verification

`pnpm --filter react-native-magic-toast-example web`, Chromium at 420x820.

Before, blank page and one console error:

![blank page](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-2026-07-28/magic-toast/2026-07-28/example-blank-before.png)

After, the mount toast fires and both buttons work:

![success toast](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-2026-07-28/magic-toast/2026-07-28/toast-success.png)
![alert toast](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-2026-07-28/magic-toast/2026-07-28/toast-alert.png)

The toast's own 3s auto-hide timer is stubbed out in those two shots so it stays on screen long enough to capture. Nothing else about it is touched.

oxlint, oxfmt and both typechecks pass.
