### PR TITLE
fix(build): keep the tests out of the published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "!ios/build",
     "!**/__tests__",
     "!**/__fixtures__",
-    "!**/__mocks__"
+    "!**/__mocks__",
+    "!**/__snapshots__",
+    "!**/*.test.*"
   ],
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -104,9 +106,6 @@
     ]
   },
   "jest": {
-    "moduleNameMapper": {
-      "\\.svg": "<rootDir>/src/__mocks__/svgMock.ts"
-    },
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
@@ -139,6 +138,7 @@
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",
+    "exclude": "**/{__tests__/**,__fixtures__/**,__mocks__/**,__snapshots__/**,*.test.*,*.spec.*}",
     "targets": [
       "commonjs",
       "module",


### PR DESCRIPTION
npm has been shipping the test suite. `files` excludes `__tests__`, `__fixtures__` and `__mocks__`, and none of those three directories exists in this repo. The one test is `src/index.test.tsx` with its snapshot in `src/__snapshots__`, so both went out, and bob compiled the test into `lib/commonjs` and `lib/module` and shipped those too. Eight files, one of them importing `@testing-library/react-native`, which is a devDependency a consumer doesn't have. `index` never imports any of it, so nothing breaks on install.

101 files and 120.2 kB unpacked becomes 93 and 58.0 kB.

## Change

`files` gains `!**/__snapshots__` and `!**/*.test.*`. bob gets an `exclude` glob so it stops compiling the test at all; its default is `**/{__tests__,__fixtures__,__mocks__}/**`, the same three directories.

Jest reads its own config and still finds the test.

The `moduleNameMapper` for `src/__mocks__/svgMock.ts` goes with it. That file has never existed in this repo and nothing imports a `.svg`; the icons are `react-native-svg` components in `.tsx`. It would only have mattered the day someone added a real `.svg` import, and then it would have failed on the missing mock.

## Verification

![npm pack, before and after](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/magic-toast-2026-07-28/magic-toast/2026-07-28/tarball.png)

`diff -rq` across the two unpacked tarballs comes back with the eight removed test files and `package.json`. Every file a consumer imports is byte-identical.
