### PR TITLE
ci: release from CI instead of a local release-it run

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -1,8 +1,8 @@
 name: 🛠️ Branch Checkup
 
+# Pull requests only. release.yml runs the same shared job on master, so
+# leaving `push` here would run every check twice on every merge.
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: 🚀 Release
+
+# Pushes to master go through here. The checkup runs first, then
+# tools/release-plan.mjs decides whether the commits since the last tag warrant
+# a release, and only then does the shared workflow run release-it.
+#
+# The plan step is not optional. release-it's Version plugin falls back to a
+# CI-default `patch` when the conventional-changelog plugin has no
+# recommendation, so without it a `ci:`-only push would publish, and so would
+# the `chore: release X` commit release-it pushes at the end of its own run,
+# forever.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel: a half-finished release can leave a tag with nothing published
+  # under it. Queue instead.
+  group: magic-toast-release
+  cancel-in-progress: false
+
+jobs:
+  # The same job branch-validation.yml runs on pull requests. Master no longer
+  # runs that workflow, so this is where a push to master gets checked, and the
+  # release below cannot start until it passes.
+  checkup:
+    uses: GSTJ/magic/.github/workflows/ci.yml@v1
+    with:
+      build-command: pnpm run build
+      test-command: pnpm test
+      extra-command: pnpm run changelog:check
+      turbo-cache: false
+
+  plan:
+    name: 🧾 Plan
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.plan.outputs.release }}
+      version: ${{ steps.plan.outputs.version }}
+    steps:
+      - name: 🏗 Checkout
+        uses: actions/checkout@v7
+        with:
+          # The plan reads every tag and every commit since the last one.
+          fetch-depth: 0
+
+      - name: 🏗 Setup Node + pnpm
+        uses: GSTJ/magic/.github/actions/setup@v1
+
+      - name: 🧾 Plan the release
+        id: plan
+        run: node tools/release-plan.mjs
+
+  release:
+    needs: [checkup, plan]
+    if: needs.plan.outputs.release == 'true'
+    uses: GSTJ/magic/.github/workflows/release.yml@v1
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # release-it commits the version bump and CHANGELOG.md and pushes both to
+      # master. The ruleset requires a pull request there and bypasses only for
+      # the admin role, which GITHUB_TOKEN does not hold. A GitHub Actions
+      # Integration cannot be added as a bypass actor on a personal account
+      # ("must be part of the ruleset source or owner organization"), so the
+      # push goes out under a PAT that is.
+      GH_PAT: ${{ secrets.GH_PAT }}

--- a/oxlint.config.mts
+++ b/oxlint.config.mts
@@ -11,10 +11,16 @@ export default extendConfig(reactNative, {
   ignorePatterns: ["**/lib/**"],
   overrides: [
     {
-      // tools/ holds the changelog CLI. Printing to the terminal is what it is
-      // for — the CI job reads its output.
+      // tools/ holds the changelog and release CLIs. Printing to the terminal
+      // is what they are for — the CI job reads their output. `process.env` is
+      // how a GitHub Actions step is handed GITHUB_OUTPUT and
+      // GITHUB_STEP_SUMMARY; the validated-env-module the rule asks for is an
+      // app-code boundary and there is no app here.
       files: ["tools/**"],
-      rules: { "no-console": "off" },
+      rules: {
+        "no-console": "off",
+        "no-restricted-properties": "off",
+      },
     },
     {
       // release-it's own config. `${version}` and `${changelog}` are release-it

--- a/tools/release-plan.mjs
+++ b/tools/release-plan.mjs
@@ -1,0 +1,113 @@
+// Decides whether a push to master warrants a release, so the release workflow
+// can skip instead of publishing something.
+//
+// release-it cannot answer this on its own. When the conventional-changelog
+// plugin has no recommendation, release-it's Version plugin falls back to a
+// CI-default `patch` of the latest version, so a `ci:`-only push would publish,
+// and the `chore: release X` commit release-it pushes itself would publish
+// again, and again. The bump has to be decided before release-it starts.
+//
+// The recommendation comes from tools/changelog-preset.mjs, the same type list
+// the changelog renders from, so `effect: "changelog"` and `effect: "hidden"`
+// types cannot move the version here either. tools/changelog-check.mjs is the
+// control for that.
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+
+import { Bumper } from "conventional-recommended-bump";
+
+import preset, { TYPES } from "./changelog-preset.mjs";
+
+/**
+ * `semver.inc` for the three release types this can produce. Written out rather
+ * than pulled from `semver`, which is only in the tree as a transitive of
+ * release-it and would break the moment that changed.
+ *
+ * @param {string} version
+ * @param {string} releaseType
+ * @returns {string}
+ */
+const increment = (version, releaseType) => {
+  const [major, minor, patch] = version.split(".").map(Number);
+  if ([major, minor, patch].some((part) => !Number.isInteger(part))) {
+    throw new Error(`package.json version is not plain x.y.z: ${version}`);
+  }
+  if (releaseType === "major") return `${major + 1}.0.0`;
+  if (releaseType === "minor") return `${major}.${minor + 1}.0`;
+  if (releaseType === "patch") return `${major}.${minor}.${patch + 1}`;
+  throw new Error(`unexpected release type: ${releaseType}`);
+};
+
+/** @param {string[]} args */
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" }).trim();
+
+/**
+ * @param {string} name
+ * @param {string} value
+ */
+const output = (name, value) => {
+  console.log(`${name}=${value}`);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+  }
+};
+
+/** @param {string} text */
+const summary = (text) => {
+  console.log(text);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${text}\n`);
+  }
+};
+
+const { version: current } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+const tag = (() => {
+  try {
+    return git("describe", "--tags", "--abbrev=0", "--match", "v*");
+  } catch {
+    return null;
+  }
+})();
+
+// Same double cast .release-it.mjs needs: the preset publishes
+// `createPreset(config?): {}`, so its own type doesn't describe the `whatBump`
+// it returns.
+const { whatBump } =
+  /** @type {{ whatBump: Parameters<Bumper["bump"]>[0] }} */ (
+    /** @type {unknown} */ (await preset)
+  );
+
+const bumper = new Bumper(process.cwd());
+bumper.loadPreset({ name: "conventionalcommits", types: TYPES });
+const { releaseType } = /** @type {{ releaseType?: string }} */ (
+  await bumper.bump(whatBump)
+);
+
+if (!releaseType) {
+  output("release", "false");
+  summary(
+    tag
+      ? `Nothing to release. No commit since \`${tag}\` carries a type that bumps the version.`
+      : "Nothing to release. No commit carries a type that bumps the version.",
+  );
+  process.exit(0);
+}
+
+const next = increment(current, releaseType);
+
+if (git("tag", "--list", `v${next}`)) {
+  // A tag that already exists means a release ran and something after it did
+  // not. Publishing over it is not something to guess at.
+  summary(`\`v${next}\` already exists. Refusing to release over it.`);
+  console.error(`::error::v${next} already exists.`);
+  process.exit(1);
+}
+
+output("release", "true");
+output("version", next);
+summary(
+  `Releasing \`${current}\` -> \`${next}\` (${releaseType}), from the commits since \`${tag ?? "the first commit"}\`.`,
+);


### PR DESCRIPTION
Releases run from CI now. Pushing to master runs the shared checkup, works out whether the commits since the last tag warrant a release, and publishes if they do.

v1.0.0 went out on 26 July and 21 commits have landed behind it since. `pnpm run release` is a local command needing an npm token and a GitHub token on someone's laptop, and nobody ran it.

## Change

`.github/workflows/release.yml` hands off to `GSTJ/magic/.github/workflows/release.yml@v1`, which is what react-native-magic-modal already publishes through. Callers own their `.release-it.mjs`, so how the version, changelog, tag and release body get produced is untouched.

`branch-validation.yml` drops its `push` trigger. release.yml calls the same shared job on master under the same job name, so the status context the ruleset requires on pull requests is byte-identical.

## Plan step

`tools/release-plan.mjs` decides whether there's anything to release, and the workflow skips the publish job when there isn't.

release-it can't answer that itself. When the conventional-changelog plugin returns no recommendation, release-it's Version plugin falls back to a CI-default `patch` of the latest version. So a `ci:`-only push to master would publish, then the `chore: release X` commit release-it pushes at the end of its own run would publish again, then that one's would.

The recommendation comes from `tools/changelog-preset.mjs`, the same type list the changelog renders from, so `effect: "changelog"` and `effect: "hidden"` types can't move the version here either and `tools/changelog-check.mjs` stays the control for both. The script also refuses to run when the tag it would create already exists, the state a release that published and then failed leaves behind.

| state, run against a throwaway clone | result |
|---|---|
| 21 commits since `v1.0.0`, 5 of them `fix:` | `release=true`, `1.0.0 -> 1.0.1` |
| tag at HEAD, nothing since | `release=false` |
| one `ci:` commit since the tag | `release=false` |
| `fix:` since the tag, but `v1.0.1` already exists | exit 1, refuses |

`oxlint.config.mts` turns `no-restricted-properties` off under `tools/**`, alongside the `no-console` exemption already there. `process.env` is how a GitHub Actions step is handed `GITHUB_OUTPUT` and `GITHUB_STEP_SUMMARY`, and the validated env module the rule wants is an app-code boundary that doesn't exist in this repo.

## Repository config

`NPM_TOKEN` and `GH_PAT` are now set on this repo, matching react-native-magic-modal.

`GH_PAT` is there because release-it commits the version bump and CHANGELOG.md and pushes both to master. The ruleset requires a pull request there and bypasses only for the admin role, which `GITHUB_TOKEN` does not hold. Adding the GitHub Actions integration as a bypass actor is rejected on a personal account: `Actor GitHub Actions integration must be part of the ruleset source or owner organization`.

What's in `GH_PAT` today is a `gho_` OAuth token off the `gh` CLI, and it dies whenever that login is refreshed. I'd swap it for a fine-grained PAT on this repo alone, `contents: write` plus `pull requests: write`.

## Rehearsal

release-it run in a throwaway clone of this branch merged with #16, with `--no-git.push --no-npm.publish --no-github.release`, so it did the version bump, the changelog write, the commit and the tag and stopped there:

- `1.0.0 -> 1.0.1`
- the `header` string in `.release-it.mjs` holds the preamble in place and the new section lands directly under it
- Bug Fixes, Code Refactoring, Chores and Documentation all render; `ci:` and `style:` stay hidden
- the tag annotation carries the same section as the changelog, headings intact, which is what `git show v1.0.1` prints
