### PR TITLE
feat(toast): move onto magic-modal and pass the handle through

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,52 +11,67 @@ A beautiful Toast library that can be called imperatively from anywhere!
 ## Installation
 
 ```sh
-npx expo install react-native-magic-toast react-native-magic-modal react-native-safe-area-context react-native-reanimated react-native-gesture-handler react-native-worklets
+npx expo install react-native-magic-toast magic-modal react-native-safe-area-context react-native-reanimated react-native-gesture-handler react-native-screens react-native-worklets
 ```
 
-This toast uses [react-native-magic-modal](https://github.com/GSTJ/react-native-magic-modal) as a base for displaying it anywhere. [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) is here to prevent the modal message from being underneath safe areas.
+This toast uses [magic-modal](https://github.com/GSTJ/magic-modal) as a base for displaying it anywhere. [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) is here to prevent the modal message from being underneath safe areas.
 
-magic-modal v7 sets the floor for the whole stack:
+magic-modal v10 sets the floor for the whole stack:
 
 | Package                        | Minimum |
 | ------------------------------ | ------- |
 | react                          | 18      |
 | react-native                   | 0.81    |
-| react-native-reanimated        | 4       |
+| react-native-reanimated        | 4.1     |
 | react-native-gesture-handler   | 2.20    |
+| react-native-screens           | 4.19    |
 | react-native-worklets          | 0.5     |
 | react-native-safe-area-context | 5       |
 
 Reanimated 4 needs its Babel plugin. `babel-preset-expo` adds it for you; outside Expo, put `react-native-worklets/plugin` last in the plugin list of your `babel.config.js`.
 
+Install magic-modal yourself and keep one copy of it. Your application mounts the portal, and this package calls into the same module instance; a second copy has a portal ref nothing ever fills.
+
+Older versions of this package depended on `react-native-magic-modal`, which is the same library under its previous name. Uninstall it once nothing else in your tree imports it.
+
 If your app can't move to RN 0.81 yet, stay on `react-native-magic-toast@0.4.x`, which tracks magic-modal v4.
+
+Web is out of scope here. `magic-modal` itself runs in the browser — import it directly and render your own toast component through it.
 
 ## Usage
 
-Insert a SafeAreaProvider encapsulating your app and a MagicModalPortal right beneath it
+Mount `MagicModalPortal` inside a `GestureHandlerRootView`, with a `SafeAreaProvider` around it so toasts can read the top inset:
 
 ```js
-import { SafeAreaProvider } from "react-native-safe-area-context";
-import { MagicModalPortal } from "react-native-magic-modal";
+import { MagicModalPortal } from "magic-modal";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import {
+  SafeAreaProvider,
+  initialWindowMetrics,
+} from "react-native-safe-area-context";
 
 export default function App() {
   return (
-    <SafeAreaProvider>
-      <MagicModalPortal />
-      // <Router />
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+        {/* <Router /> */}
+        <MagicModalPortal />
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }
 ```
+
+The gesture root is required on native. The portal owns the swipe surface a toast is dismissed with, and gesture handling needs a root view above it.
 
 Then, you are free to use the magicToast as shown from anywhere you want.
 
 One ordering rule: `SafeAreaProvider` renders `null` until it has measured its
 insets, so `MagicModalPortal` is not mounted during the first commit. Calling
 `magicToast` from the mount effect of the component that renders the provider
-throws `MagicModalPortal not found`. Call it from a component below the portal,
-or pass `initialMetrics={initialWindowMetrics}` to the provider, which covers
-iOS and Android but not web.
+throws `MagicModalPortal not found`. `initialMetrics={initialWindowMetrics}`,
+as above, covers iOS and Android; on web it is null and does nothing, so there
+call the toast from a component below the portal.
 
 ```js
 import { magicToast } from "react-native-magic-toast";
@@ -80,6 +95,43 @@ magicToast.show(() => (
   </Toast.Container>
 ));
 ```
+
+## The handle a toast hands back
+
+Every one of `alert`, `success` and `show` returns magic-modal's `ModalHandle` as-is.
+
+Await it to find out when, and why, the toast left the screen:
+
+```js
+import { MagicModalHideReason } from "magic-modal";
+
+const { reason } = await magicToast.success("Saved");
+
+if (reason === MagicModalHideReason.SWIPE_COMPLETE) {
+  // the user swiped it away before it timed out
+}
+```
+
+Or keep it, and drive the toast while it is still up:
+
+```js
+const toast = magicToast.show(() => <UploadToast progress={0} />);
+
+toast.update(() => <UploadToast progress={50} />);
+toast.hide(); // takes it off screen now
+toast.modalID; // identifies this entry in the stack
+```
+
+`update`, `hide` and `modalID` hang off the promise object, so anything that
+adopts the handle hands the caller a plain promise without them. Returning it
+from an `async` function is the usual way to lose them:
+
+```js
+// `modalID`, `update` and `hide` are gone from what the caller receives.
+const notify = async () => magicToast.success("Saved");
+```
+
+Return the handle from a normal function, or await it where you show the toast.
 
 ## Contributing
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,26 +1,73 @@
+import type { ModalHandle } from "magic-modal";
+
 import * as React from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
-import { MagicModalPortal } from "react-native-magic-modal";
+import { MagicModalPortal, useMagicModal } from "magic-modal";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { magicToast } from "react-native-magic-toast";
-import { SafeAreaProvider } from "react-native-safe-area-context";
+import {
+  SafeAreaProvider,
+  initialWindowMetrics,
+} from "react-native-safe-area-context";
 
 const colors = {
   button: "#000000",
   buttonText: "#ffffff",
+  customToast: "#3b2f63",
+  customToastText: "#ffffff",
+  result: "#666666",
 };
 
 /**
- * The demo screen, rendered below `MagicModalPortal` so the portal is mounted
- * by the time this component's effect runs.
+ * A toast built from scratch, to show what `magicToast.show` takes: any
+ * component, rendered by the portal with the toast's swipe and placement.
  *
- * Firing the first toast from the component that renders `SafeAreaProvider`
- * does not work. The provider renders `null` until it has its insets, so
- * `MagicModalPortal` has not mounted yet and `magicModal.show` throws
- * "MagicModalPortal not found". `initialMetrics` covers that on iOS and
- * Android and does nothing on web, where `initialWindowMetrics` is null.
+ * It runs its own timer because `Toast.Container` — the piece that owns the
+ * duration — is not exported from the package yet.
+ */
+const CustomToast = () => {
+  const { hide } = useMagicModal();
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => hide(), 3000);
+    return () => clearTimeout(timeout);
+  }, [hide]);
+
+  return (
+    <View style={styles.customToast}>
+      <Text style={styles.customToastText}>A toast of my own 🎨</Text>
+    </View>
+  );
+};
+
+/**
+ * The demo screen. `MagicModalPortal` is a sibling below it, which is fine:
+ * the portal's ref is attached during the commit, before this component's
+ * effect runs.
+ *
+ * `initialMetrics` is what makes that true on the very first commit —
+ * `SafeAreaProvider` renders `null` until it has measured its insets, and a
+ * `null` provider has no portal under it to find. It covers iOS and Android,
+ * and does nothing on web, where `initialWindowMetrics` is null.
  */
 const Demo = () => {
+  const [result, setResult] = React.useState("—");
+  const dismissals = React.useRef(0);
+
+  /**
+   * Awaits a handle and reports why that toast went away. Numbered, because
+   * consecutive toasts often leave for the same reason and the line has to
+   * visibly change when one does.
+   */
+  const track = React.useCallback(async (handle: ModalHandle<void>) => {
+    const { reason } = await handle;
+    dismissals.current += 1;
+    setResult(`#${dismissals.current} ${reason}`);
+  }, []);
+
+  // Fired, not tracked: the reported reason belongs to whatever the person
+  // watching does next, and awaiting this one here would settle it for them.
   React.useEffect(() => {
     magicToast.success("It works!!");
   }, []);
@@ -29,31 +76,58 @@ const Demo = () => {
     <View style={styles.container}>
       <TouchableOpacity
         style={styles.button}
-        onPress={() => magicToast.alert("Oops! Something went wrong 😬")}
+        onPress={() => track(magicToast.alert("Oops! Something went wrong 😬"))}
       >
         <Text style={styles.buttonText}>Press me to fire an alert!</Text>
       </TouchableOpacity>
 
       <TouchableOpacity
         style={styles.button}
-        onPress={() => magicToast.success("Hurray! It works 🎉")}
+        onPress={() => track(magicToast.success("Hurray! It works 🎉"))}
       >
         <Text style={styles.buttonText}>Press me to fire a success toast!</Text>
       </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => track(magicToast.show<void>(CustomToast))}
+      >
+        <Text style={styles.buttonText}>Press me to fire a custom toast!</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => {
+          // A ten second toast, taken off screen after one. `hide` hangs off
+          // the handle, so the caller can close a toast it opened.
+          const toast = magicToast.success("Hiding this early…", 10_000);
+          void track(toast);
+          setTimeout(() => toast.hide(), 1000);
+        }}
+      >
+        <Text style={styles.buttonText}>Press me to hide a toast early!</Text>
+      </TouchableOpacity>
+
+      <Text style={styles.result}>last dismissal: {result}</Text>
     </View>
   );
 };
 
 const App = () => (
-  <SafeAreaProvider>
-    <MagicModalPortal />
-    <Demo />
-  </SafeAreaProvider>
+  <GestureHandlerRootView style={styles.root}>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <Demo />
+      <MagicModalPortal />
+    </SafeAreaProvider>
+  </GestureHandlerRootView>
 );
 
 export default App;
 
 const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
   container: {
     flex: 1,
     alignItems: "center",
@@ -71,5 +145,20 @@ const styles = StyleSheet.create({
   buttonText: {
     color: colors.buttonText,
     fontWeight: "bold",
+  },
+  customToast: {
+    backgroundColor: colors.customToast,
+    paddingTop: 70,
+    paddingBottom: 25,
+    paddingHorizontal: 25,
+    alignItems: "center",
+  },
+  customToastText: {
+    color: colors.customToastText,
+    fontWeight: "bold",
+  },
+  result: {
+    color: colors.result,
+    marginTop: 10,
   },
 });

--- a/example/package.json
+++ b/example/package.json
@@ -15,11 +15,11 @@
   "dependencies": {
     "@expo/metro-runtime": "~55.0.12",
     "expo": "^55.0.28",
+    "magic-modal": "^10.2.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
     "react-native-gesture-handler": "~2.30.0",
-    "react-native-magic-modal": "^7.0.3",
     "react-native-magic-toast": "workspace:*",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.6.2",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "react-native-magic-modal": "^7.0.3",
-    "react-native-safe-area-context": "^5.6.2",
     "react-native-svg": "^15.0.0"
   },
   "devDependencies": {
@@ -74,6 +72,7 @@
     "jest": "^29.7.0",
     "jest-expo": "^55.0.20",
     "magic-codemods": "^1.1.0",
+    "magic-modal": "^10.2.0",
     "magic-oxfmt-config": "^1.2.0",
     "magic-oxlint-config": "^2.0.0",
     "magic-tsconfig": "^1.2.0",
@@ -85,6 +84,7 @@
     "react-native-builder-bob": "^0.43.0",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "4.3.1",
+    "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "~4.23.0",
     "react-native-worklets": "~0.8.3",
     "react-test-renderer": "19.2.0",
@@ -92,12 +92,13 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "magic-modal": "^10.2.0",
     "react": ">=18.0.0",
     "react-native": ">=0.81.0",
     "react-native-gesture-handler": ">=2.20.0",
-    "react-native-magic-modal": "^7.0.0",
-    "react-native-reanimated": ">=4.0.0",
+    "react-native-reanimated": ">=4.1.0",
     "react-native-safe-area-context": ">=5.0.0",
+    "react-native-screens": ">=4.19.0",
     "react-native-worklets": ">=0.5.0"
   },
   "commitlint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,12 +12,6 @@ importers:
 
   .:
     dependencies:
-      react-native-magic-modal:
-        specifier: ^7.0.3
-        version: 7.1.0(6687163ce17babf79bb6ce8500d8e02c)
-      react-native-safe-area-context:
-        specifier: ^5.6.2
-        version: 5.6.2(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
       react-native-svg:
         specifier: ^15.0.0
         version: 15.15.5(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
@@ -70,6 +64,9 @@ importers:
       magic-codemods:
         specifier: ^1.1.0
         version: 1.1.0
+      magic-modal:
+        specifier: ^10.2.0
+        version: 10.2.0(d8df96e54f5c5cfa1638368345c9f39e)
       magic-oxfmt-config:
         specifier: ^1.2.0
         version: 1.2.0(oxfmt@0.60.0)
@@ -103,6 +100,9 @@ importers:
       react-native-reanimated:
         specifier: 4.3.1
         version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
+      react-native-safe-area-context:
+        specifier: ^5.6.2
+        version: 5.6.2(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
       react-native-screens:
         specifier: ~4.23.0
         version: 4.23.0(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
@@ -127,6 +127,9 @@ importers:
       expo:
         specifier: ^55.0.28
         version: 55.0.28(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      magic-modal:
+        specifier: ^10.2.0
+        version: 10.2.0(d8df96e54f5c5cfa1638368345c9f39e)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -139,9 +142,6 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.30.0
         version: 2.30.1(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-      react-native-magic-modal:
-        specifier: ^7.0.3
-        version: 7.1.0(6687163ce17babf79bb6ce8500d8e02c)
       react-native-magic-toast:
         specifier: workspace:*
         version: link:..
@@ -3686,6 +3686,27 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
+  magic-modal@10.2.0:
+    resolution: {integrity: sha512-0vH3lKDqgEYn6ZbgFpAcErro7LjPpsEJ70ScQA1i/C1uSQP5AbmDK+YS/OgWKJ8N1OYzyiI7O9nCNXfXDkZWFQ==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-native: '>=0.81.0'
+      react-native-gesture-handler: '>=2.20.0'
+      react-native-reanimated: '>=4.1.0'
+      react-native-screens: '>=4.19.0'
+      react-native-worklets: '>=0.5.0'
+    peerDependenciesMeta:
+      react-native:
+        optional: true
+      react-native-gesture-handler:
+        optional: true
+      react-native-reanimated:
+        optional: true
+      react-native-screens:
+        optional: true
+      react-native-worklets:
+        optional: true
+
   magic-oxfmt-config@1.2.0:
     resolution: {integrity: sha512-Wq46MqLnrZTJx1V2nJumdyW8OgA4URnhrfkYx6NYeewQRJAN+wiS1lxu1+5gU6BvlDetmbz7Ol/Xb8sxVXgW3A==}
     engines: {node: '>=22.18.0'}
@@ -4349,18 +4370,6 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
-
-  react-native-magic-modal@7.1.0:
-    resolution: {integrity: sha512-XI+94aQAAh8SiV4BWIfRu0yIZoQSwU/KEdy46YnRS9kOJ5OYTyY9lv+5G3OPEg0G0lwIX4xBdbFu8hFRk+AUpw==}
-    peerDependencies:
-      react: '>=18.0.0'
-      react-native: '>=0.81.0'
-      react-native-gesture-handler: '>=2.20.0'
-      react-native-reanimated: '>=4.0.0'
-      react-native-worklets: '>=0.5.0'
-    peerDependenciesMeta:
-      react-native-worklets:
-        optional: true
 
   react-native-reanimated@4.3.1:
     resolution: {integrity: sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q==}
@@ -9361,6 +9370,16 @@ snapshots:
     dependencies:
       ts-morph: 28.0.0
 
+  magic-modal@10.2.0(d8df96e54f5c5cfa1638368345c9f39e):
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      react-native: 0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      react-native-gesture-handler: 2.30.1(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)
+
   magic-oxfmt-config@1.2.0(oxfmt@0.60.0):
     optionalDependencies:
       oxfmt: 0.60.0
@@ -10240,15 +10259,6 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-
-  react-native-magic-modal@7.1.0(6687163ce17babf79bb6ce8500d8e02c):
-    dependencies:
-      react: 19.2.0
-      react-native: 0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      react-native-gesture-handler: 2.30.1(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-    optionalDependencies:
-      react-native-worklets: 0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1)
 
   react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)(supports-color@8.1.1))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ overrides:
 minimumReleaseAgeExclude:
   - eslint-plugin-safe-jsx@1.3.5
   - magic-codemods@1.1.0
+  - magic-modal@10.2.0
   - magic-oxfmt-config@1.2.0
   - magic-oxlint-config@2.0.0
   - magic-oxlint-plugin@1.2.0

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -1,392 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MagicToast renders an alert toast 1`] = `
-<RNSFullWindowOverlay
-  style={
-    [
-      {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      {
-        "height": 1334,
-        "width": 750,
-      },
-    ]
-  }
->
-  <View
-    style={
-      [
-        {
-          "bottom": 0,
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        },
-        {
-          "pointerEvents": "box-none",
-        },
-      ]
-    }
-  >
-    <View
-      style={
-        [
-          {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
-          {
-            "pointerEvents": "box-none",
-          },
-        ]
-      }
-    >
-      <View
-        collapsable={false}
-        entering={
-          FadeIn {
-            "build": [Function],
-            "durationV": 250,
-            "randomizeDelay": false,
-            "reduceMotionV": "system",
-          }
-        }
-        exiting={
-          FadeOut {
-            "build": [Function],
-            "durationV": 250,
-            "randomizeDelay": false,
-            "reduceMotionV": "system",
-          }
-        }
-        jestAnimatedProps={
-          {
-            "value": {},
-          }
-        }
-        jestAnimatedStyle={
-          {
-            "value": {},
-          }
-        }
-        jestInlineStyle={
-          {
-            "height": "100%",
-            "position": "absolute",
-            "width": "100%",
-          }
-        }
-        pointerEvents="none"
-        style={
-          [
-            {
-              "height": "100%",
-              "position": "absolute",
-              "width": "100%",
-            },
-          ]
-        }
-      >
-        <View
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={true}
-          jestAnimatedProps={
-            {
-              "value": {},
-            }
-          }
-          jestAnimatedStyle={
-            {
-              "value": {
-                "opacity": 1,
-              },
-            }
-          }
-          jestInlineStyle={
-            [
-              {
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "flex": 1,
-              },
-              {
-                "backgroundColor": "transparent",
-              },
-            ]
-          }
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            [
-              {
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "flex": 1,
-              },
-              {
-                "opacity": 1,
-              },
-              {
-                "backgroundColor": "transparent",
-              },
-            ]
-          }
-          testID="magic-modal-backdrop"
-        />
-      </View>
-      <View
-        collapsable={false}
-        jestAnimatedProps={
-          {
-            "value": {},
-          }
-        }
-        jestAnimatedStyle={
-          {
-            "value": {
-              "transform": [
-                {
-                  "translateX": 0,
-                },
-                {
-                  "translateY": 0,
-                },
-              ],
-            },
-          }
-        }
-        jestInlineStyle={
-          [
-            {
-              "flex": 1,
-              "justifyContent": "center",
-            },
-            {
-              "pointerEvents": "box-none",
-            },
-          ]
-        }
-        style={
-          [
-            {
-              "flex": 1,
-              "justifyContent": "center",
-            },
-            {
-              "pointerEvents": "box-none",
-            },
-            {
-              "transform": [
-                {
-                  "translateX": 0,
-                },
-                {
-                  "translateY": 0,
-                },
-              ],
-            },
-          ]
-        }
-      >
-        <View
-          collapsable={false}
-          entering={
-            FadeInUp {
-              "build": [Function],
-              "durationV": 250,
-              "randomizeDelay": false,
-              "reduceMotionV": "system",
-            }
-          }
-          exiting={
-            FadeOutUp {
-              "build": [Function],
-              "durationV": 250,
-              "randomizeDelay": false,
-              "reduceMotionV": "system",
-            }
-          }
-          jestAnimatedProps={
-            {
-              "value": {},
-            }
-          }
-          jestAnimatedStyle={
-            {
-              "value": {},
-            }
-          }
-          jestInlineStyle={
-            [
-              {
-                "flex": 1,
-                "justifyContent": "center",
-              },
-              {
-                "pointerEvents": "box-none",
-              },
-              {
-                "justifyContent": "flex-start",
-              },
-            ]
-          }
-          style={
-            [
-              {
-                "flex": 1,
-                "justifyContent": "center",
-              },
-              {
-                "pointerEvents": "box-none",
-              },
-              {
-                "justifyContent": "flex-start",
-              },
-            ]
-          }
-        >
-          <View
-            collapsable={false}
-            style={
-              [
-                {
-                  "flex": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "pointerEvents": "box-none",
-                },
-                {
-                  "justifyContent": "flex-start",
-                },
-              ]
-            }
-          >
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "backgroundColor": "#191919",
-                    "flexDirection": "row",
-                    "gap": 15,
-                    "padding": 25,
-                  },
-                  {
-                    "paddingTop": 25,
-                  },
-                  undefined,
-                ]
-              }
-              testID="magic-toast"
-            >
-              <RNSVGSvgView
-                align="xMidYMid"
-                bbHeight={20}
-                bbWidth={20}
-                fill="white"
-                focusable={false}
-                height={20}
-                meetOrSlice={0}
-                minX={0}
-                minY={0}
-                style={
-                  [
-                    {
-                      "backgroundColor": "transparent",
-                      "borderWidth": 0,
-                    },
-                    {
-                      "flex": 0,
-                      "height": 20,
-                      "width": 20,
-                    },
-                  ]
-                }
-                vbHeight={512}
-                vbWidth={512}
-                width={20}
-                x="0px"
-                y="0px"
-              >
-                <RNSVGGroup
-                  fill={
-                    {
-                      "payload": 4294967295,
-                      "type": 0,
-                    }
-                  }
-                  propList={
-                    [
-                      "fill",
-                    ]
-                  }
-                >
-                  <RNSVGPath
-                    d="M501.362 383.95L320.497 51.474c-29.059-48.921-99.896-48.986-128.994 0L10.647 383.95c-29.706 49.989 6.259 113.291 64.482 113.291h361.736c58.174 0 94.203-63.251 64.497-113.291zM256 437.241c-16.538 0-30-13.462-30-30s13.462-30 30-30 30 13.462 30 30-13.462 30-30 30zm30-120c0 16.538-13.462 30-30 30s-30-13.462-30-30v-150c0-16.538 13.462-30 30-30s30 13.462 30 30v150z"
-                    fill={
-                      {
-                        "payload": 4278190080,
-                        "type": 0,
-                      }
-                    }
-                  />
-                </RNSVGGroup>
-              </RNSVGSvgView>
-              <Text
-                style={
-                  [
-                    {
-                      "color": "white",
-                      "fontWeight": "bold",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                Taveira
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</RNSFullWindowOverlay>
-`;
-
 exports[`MagicToast renders a success toast 1`] = `
 <RNSFullWindowOverlay
   style={
@@ -406,6 +19,10 @@ exports[`MagicToast renders a success toast 1`] = `
   }
 >
   <View
+    accessibilityElementsHidden={false}
+    accessibilityViewIsModal={true}
+    aria-hidden={false}
+    importantForAccessibility="auto"
     style={
       [
         {
@@ -420,8 +37,13 @@ exports[`MagicToast renders a success toast 1`] = `
         },
       ]
     }
+    testID="magic-modal-portal"
   >
     <View
+      accessibilityElementsHidden={false}
+      aria-hidden={false}
+      importantForAccessibility="auto"
+      pointerEvents="box-none"
       style={
         [
           {
@@ -436,6 +58,7 @@ exports[`MagicToast renders a success toast 1`] = `
           },
         ]
       }
+      testID="magic-modal-stack-entry"
     >
       <View
         collapsable={false}
@@ -484,11 +107,12 @@ exports[`MagicToast renders a success toast 1`] = `
         }
       >
         <View
+          accessibilityElementsHidden={true}
           accessibilityState={
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": undefined,
+              "disabled": true,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -501,9 +125,11 @@ exports[`MagicToast renders a success toast 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
+          aria-hidden={true}
           collapsable={false}
           focusable={true}
+          importantForAccessibility="no-hide-descendants"
           jestAnimatedProps={
             {
               "value": {},
@@ -580,19 +206,14 @@ exports[`MagicToast renders a success toast 1`] = `
               "flex": 1,
               "justifyContent": "center",
             },
-            {
-              "pointerEvents": "box-none",
-            },
           ]
         }
+        pointerEvents="box-none"
         style={
           [
             {
               "flex": 1,
               "justifyContent": "center",
-            },
-            {
-              "pointerEvents": "box-none",
             },
             {
               "transform": [
@@ -606,6 +227,7 @@ exports[`MagicToast renders a success toast 1`] = `
             },
           ]
         }
+        testID="magic-modal-motion-layer"
       >
         <View
           collapsable={false}
@@ -642,13 +264,11 @@ exports[`MagicToast renders a success toast 1`] = `
                 "justifyContent": "center",
               },
               {
-                "pointerEvents": "box-none",
-              },
-              {
                 "justifyContent": "flex-start",
               },
             ]
           }
+          pointerEvents="box-none"
           style={
             [
               {
@@ -656,16 +276,19 @@ exports[`MagicToast renders a success toast 1`] = `
                 "justifyContent": "center",
               },
               {
-                "pointerEvents": "box-none",
-              },
-              {
                 "justifyContent": "flex-start",
               },
             ]
           }
+          testID="magic-modal-animation-layer"
         >
           <View
+            accessibilityViewIsModal={true}
+            aria-modal={true}
             collapsable={false}
+            importantForAccessibility="auto"
+            onAccessibilityEscape={[Function]}
+            role="dialog"
             style={
               [
                 {
@@ -673,13 +296,15 @@ exports[`MagicToast renders a success toast 1`] = `
                   "justifyContent": "center",
                 },
                 {
-                  "pointerEvents": "box-none",
+                  "justifyContent": "flex-start",
                 },
                 {
-                  "justifyContent": "flex-start",
+                  "pointerEvents": "box-none",
                 },
               ]
             }
+            tabIndex={-1}
+            testID="magic-modal-dialog"
           >
             <View
               style={
@@ -744,6 +369,405 @@ exports[`MagicToast renders a success toast 1`] = `
                 >
                   <RNSVGPath
                     d="M128 24a104 104 0 1 0 104 104A104.11 104.11 0 0 0 128 24Zm45.66 85.66-56 56a8 8 0 0 1-11.32 0l-24-24a8 8 0 0 1 11.32-11.32L112 148.69l50.34-50.35a8 8 0 0 1 11.32 11.32Z"
+                    fill={
+                      {
+                        "payload": 4278190080,
+                        "type": 0,
+                      }
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+              <Text
+                style={
+                  [
+                    {
+                      "color": "white",
+                      "fontWeight": "bold",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Taveira
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNSFullWindowOverlay>
+`;
+
+exports[`MagicToast renders an alert toast 1`] = `
+<RNSFullWindowOverlay
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+      {
+        "height": 1334,
+        "width": 750,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityElementsHidden={false}
+    accessibilityViewIsModal={true}
+    aria-hidden={false}
+    importantForAccessibility="auto"
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "box-none",
+        },
+      ]
+    }
+    testID="magic-modal-portal"
+  >
+    <View
+      accessibilityElementsHidden={false}
+      aria-hidden={false}
+      importantForAccessibility="auto"
+      pointerEvents="box-none"
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "pointerEvents": "box-none",
+          },
+        ]
+      }
+      testID="magic-modal-stack-entry"
+    >
+      <View
+        collapsable={false}
+        entering={
+          FadeIn {
+            "build": [Function],
+            "durationV": 250,
+            "randomizeDelay": false,
+            "reduceMotionV": "system",
+          }
+        }
+        exiting={
+          FadeOut {
+            "build": [Function],
+            "durationV": 250,
+            "randomizeDelay": false,
+            "reduceMotionV": "system",
+          }
+        }
+        jestAnimatedProps={
+          {
+            "value": {},
+          }
+        }
+        jestAnimatedStyle={
+          {
+            "value": {},
+          }
+        }
+        jestInlineStyle={
+          {
+            "height": "100%",
+            "position": "absolute",
+            "width": "100%",
+          }
+        }
+        pointerEvents="none"
+        style={
+          [
+            {
+              "height": "100%",
+              "position": "absolute",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityElementsHidden={true}
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": true,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={false}
+          aria-hidden={true}
+          collapsable={false}
+          focusable={true}
+          importantForAccessibility="no-hide-descendants"
+          jestAnimatedProps={
+            {
+              "value": {},
+            }
+          }
+          jestAnimatedStyle={
+            {
+              "value": {
+                "opacity": 1,
+              },
+            }
+          }
+          jestInlineStyle={
+            [
+              {
+                "backgroundColor": "rgba(0, 0, 0, 0.5)",
+                "flex": 1,
+              },
+              {
+                "backgroundColor": "transparent",
+              },
+            ]
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              {
+                "backgroundColor": "rgba(0, 0, 0, 0.5)",
+                "flex": 1,
+              },
+              {
+                "opacity": 1,
+              },
+              {
+                "backgroundColor": "transparent",
+              },
+            ]
+          }
+          testID="magic-modal-backdrop"
+        />
+      </View>
+      <View
+        collapsable={false}
+        jestAnimatedProps={
+          {
+            "value": {},
+          }
+        }
+        jestAnimatedStyle={
+          {
+            "value": {
+              "transform": [
+                {
+                  "translateX": 0,
+                },
+                {
+                  "translateY": 0,
+                },
+              ],
+            },
+          }
+        }
+        jestInlineStyle={
+          [
+            {
+              "flex": 1,
+              "justifyContent": "center",
+            },
+          ]
+        }
+        pointerEvents="box-none"
+        style={
+          [
+            {
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "transform": [
+                {
+                  "translateX": 0,
+                },
+                {
+                  "translateY": 0,
+                },
+              ],
+            },
+          ]
+        }
+        testID="magic-modal-motion-layer"
+      >
+        <View
+          collapsable={false}
+          entering={
+            FadeInUp {
+              "build": [Function],
+              "durationV": 250,
+              "randomizeDelay": false,
+              "reduceMotionV": "system",
+            }
+          }
+          exiting={
+            FadeOutUp {
+              "build": [Function],
+              "durationV": 250,
+              "randomizeDelay": false,
+              "reduceMotionV": "system",
+            }
+          }
+          jestAnimatedProps={
+            {
+              "value": {},
+            }
+          }
+          jestAnimatedStyle={
+            {
+              "value": {},
+            }
+          }
+          jestInlineStyle={
+            [
+              {
+                "flex": 1,
+                "justifyContent": "center",
+              },
+              {
+                "justifyContent": "flex-start",
+              },
+            ]
+          }
+          pointerEvents="box-none"
+          style={
+            [
+              {
+                "flex": 1,
+                "justifyContent": "center",
+              },
+              {
+                "justifyContent": "flex-start",
+              },
+            ]
+          }
+          testID="magic-modal-animation-layer"
+        >
+          <View
+            accessibilityViewIsModal={true}
+            aria-modal={true}
+            collapsable={false}
+            importantForAccessibility="auto"
+            onAccessibilityEscape={[Function]}
+            role="dialog"
+            style={
+              [
+                {
+                  "flex": 1,
+                  "justifyContent": "center",
+                },
+                {
+                  "justifyContent": "flex-start",
+                },
+                {
+                  "pointerEvents": "box-none",
+                },
+              ]
+            }
+            tabIndex={-1}
+            testID="magic-modal-dialog"
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#191919",
+                    "flexDirection": "row",
+                    "gap": 15,
+                    "padding": 25,
+                  },
+                  {
+                    "paddingTop": 25,
+                  },
+                  undefined,
+                ]
+              }
+              testID="magic-toast"
+            >
+              <RNSVGSvgView
+                align="xMidYMid"
+                bbHeight={20}
+                bbWidth={20}
+                fill="white"
+                focusable={false}
+                height={20}
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    {
+                      "flex": 0,
+                      "height": 20,
+                      "width": 20,
+                    },
+                  ]
+                }
+                vbHeight={512}
+                vbWidth={512}
+                width={20}
+                x="0px"
+                y="0px"
+              >
+                <RNSVGGroup
+                  fill={
+                    {
+                      "payload": 4294967295,
+                      "type": 0,
+                    }
+                  }
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    d="M501.362 383.95L320.497 51.474c-29.059-48.921-99.896-48.986-128.994 0L10.647 383.95c-29.706 49.989 6.259 113.291 64.482 113.291h361.736c58.174 0 94.203-63.251 64.497-113.291zM256 437.241c-16.538 0-30-13.462-30-30s13.462-30 30-30 30 13.462 30 30-13.462 30-30 30zm30-120c0 16.538-13.462 30-30 30s-30-13.462-30-30v-150c0-16.538 13.462-30 30-30s30 13.462 30 30v150z"
                     fill={
                       {
                         "payload": 4278190080,

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -3,7 +3,7 @@ import type { ViewProps, TextProps } from "react-native";
 import React, { useEffect } from "react";
 import { View, Text } from "react-native";
 
-import { useMagicModal } from "react-native-magic-modal";
+import { useMagicModal } from "magic-modal";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { styles } from "./styles";

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { render, act } from "@testing-library/react-native";
-import { MagicModalPortal } from "react-native-magic-modal";
+import { MagicModalPortal } from "magic-modal";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import { TOAST_TEST_ID } from "./components/Toast";

--- a/src/utils/alert.tsx
+++ b/src/utils/alert.tsx
@@ -1,3 +1,5 @@
+import type { ModalHandle } from "magic-modal";
+
 import React from "react";
 
 import { AlertToast } from "../components/alert-toast";
@@ -5,8 +7,12 @@ import { show } from "./show";
 
 /**
  * Shows the default alert toast.
+ *
  * @param message The message to be shown.
  * @param duration The duration of the toast.
+ * @returns The {@link ModalHandle} from {@link show}. Awaiting it resolves with
+ * `{ reason }` once the toast is off screen; `modalID`, `update()` and `hide()`
+ * hang off the same object. See {@link show} for the full contract.
  */
-export const alert = (message: string, duration?: number) =>
-  show(() => <AlertToast message={message} duration={duration} />);
+export const alert = (message: string, duration?: number): ModalHandle<void> =>
+  show<void>(() => <AlertToast message={message} duration={duration} />);

--- a/src/utils/show.tsx
+++ b/src/utils/show.tsx
@@ -1,13 +1,43 @@
-import type { ModalChildren } from "react-native-magic-modal";
+import type { ModalChildren, ModalHandle } from "magic-modal";
 
-import { magicModal } from "react-native-magic-modal";
+import { magicModal } from "magic-modal";
 
 /**
  * Shows a toast with the given component.
+ *
  * @param component The component to be shown.
+ * @returns The {@link ModalHandle} magic-modal hands back, untouched.
+ *
+ * Awaiting it resolves when the toast leaves the screen — auto-hide, swipe, or
+ * an explicit `hide()` — with `{ reason }`, plus `data` when the toast hid
+ * itself through `useMagicModal().hide(data)`.
+ *
+ * ```tsx
+ * const { reason } = await magicToast.show(() => <MyToast />);
+ * ```
+ *
+ * The handle is that promise with `modalID`, `update()` and `hide()` hanging
+ * off it, so a toast can be driven while it is still up:
+ *
+ * ```tsx
+ * const toast = magicToast.show(() => <UploadToast progress={0} />);
+ * toast.update(() => <UploadToast progress={50} />);
+ * toast.hide();
+ * ```
+ *
+ * Those extras live on the promise object, so anything that adopts the handle
+ * hands back a plain promise without them. Returning it from an `async`
+ * function is the common way to lose them:
+ *
+ * ```tsx
+ * // `modalID`, `update` and `hide` are gone from what the caller receives.
+ * const notify = async () => magicToast.show(() => <MyToast />);
+ * ```
+ *
+ * Return the handle from a non-async function, or await it where you show it.
  */
-export const show = (component: ModalChildren) =>
-  magicModal.show(component, {
+export const show = <T,>(component: ModalChildren): ModalHandle<T> =>
+  magicModal.show<T>(component, {
     swipeDirection: "up",
     hideBackdrop: true,
     style: { justifyContent: "flex-start" },

--- a/src/utils/success.tsx
+++ b/src/utils/success.tsx
@@ -1,3 +1,5 @@
+import type { ModalHandle } from "magic-modal";
+
 import React from "react";
 
 import { SuccessToast } from "../components/success-toast";
@@ -5,8 +7,15 @@ import { show } from "./show";
 
 /**
  * Shows the default success toast.
+ *
  * @param message The message to be shown.
  * @param duration The duration of the toast.
+ * @returns The {@link ModalHandle} from {@link show}. Awaiting it resolves with
+ * `{ reason }` once the toast is off screen; `modalID`, `update()` and `hide()`
+ * hang off the same object. See {@link show} for the full contract.
  */
-export const success = (message: string, duration?: number) =>
-  show(() => <SuccessToast message={message} duration={duration} />);
+export const success = (
+  message: string,
+  duration?: number,
+): ModalHandle<void> =>
+  show<void>(() => <SuccessToast message={message} duration={duration} />);


### PR DESCRIPTION
📝 **DESCRIPTION:**

`react-native-magic-modal` is now `magic-modal`. This moves the three touchpoints onto it and fixes the packaging around it.

- `src/utils/show.tsx`, `src/components/Toast/index.tsx` and the test import from `magic-modal`.
- `magic-modal@^10.2.0` becomes a peer plus dev dependency. It is not a runtime dependency, and neither is `react-native-safe-area-context` anymore. Both were sitting in `dependencies` **and** `peerDependencies` at once, which is how an app ends up with two copies of magic-modal: your `MagicModalPortal` fills one module's ref, this package calls the other, and `magicToast.show` throws `MagicModalPortal not found`.
- v10's floor adds `react-native-screens >=4.19.0` and lifts reanimated to `>=4.1.0`.
- `show`, `alert` and `success` return magic-modal's `ModalHandle`, typed rather than inferred, with no `any`.
- README install/setup rewritten onto `magic-modal`, and the portal is now shown inside `GestureHandlerRootView` — it was missing from both the README and `example/App.tsx`.

**What awaiting a toast does now**

`magicToast.show()` used to hand back a value whose promise you had to reach into. It hands back the handle itself now, so a bare `await magicToast.show(...)` waits for the toast to leave the screen instead of resolving straight away:

```js
const { reason } = await magicToast.success("Saved");
```

Code that destructures keeps working — v10 still carries `modalID`, and `promise` remains as an alias of the handle:

```js
const { promise, modalID } = magicToast.show(() => <MyToast />);
```

`update()`, `hide()` and `modalID` hang off the promise object, so anything that adopts the handle (returning it from an `async` function, most often) hands the caller a plain promise without them. Documented in the JSDoc on `show` and in the README.

🖼 **PRINTS & GIFS:**

Recorded on an iPhone 17 Pro simulator (iOS 26.5) from `example/App.tsx` on this branch, Release build, driven by a maestro flow. One continuous take, no cuts.

https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr18-toast-flow.mp4

| | |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr18-01-autohide.png" width="240"/> | **Auto-hide.** The toast fired from the demo screen's mount effect, which is also the check that the portal is reachable by then. It leaves on its own after 3s. |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr18-02-alert.png" width="240"/> | **`magicToast.alert`.** Resolves `#1 INTENTIONAL_HIDE` once it is off screen — the await settling on dismissal rather than immediately is the change this PR is about. |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr18-03-success.png" width="240"/> | **`magicToast.success`.** `#2`. |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr18-04-custom.png" width="240"/> | **`magicToast.show`** with a component of the app's own. `#3`. |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr18-05-early-hide.png" width="240"/> | **`handle.hide()`.** A toast opened with a 10s duration and closed after 1s by the caller, through the handle. |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr18-06-resolved.png" width="240"/> | `#4`, a second later. |

The counter on that last line is the flow's assertion target: every step waits for its own `#n`, so a toast that never resolved would fail the run rather than pass unnoticed.

**What this recording does not show: swipe-to-dismiss.** I could not drive it. Maestro's iOS swipe does not produce a gesture react-native-gesture-handler recognises — I measured the toast's position frame by frame through the swipe and it never moves, then leaves on its 3s timer with `INTENTIONAL_HIDE` instead of `SWIPE_COMPLETE`. It behaves the same with magic-modal's `FullWindowOverlay` disabled, so the overlay is not the cause and it is not specific to this migration. A real mouse drag on the simulator window was the other option and this machine has no active graphical session to post one from.

So swipe dismissal is untested here in either direction — I am not claiming this PR proves it works, and I found no evidence it broke. What I can say is narrower: `show.tsx` passes `swipeDirection: "up"` and v10 reads the same key with the same meaning, the config passthrough is unchanged in this diff, and magic-modal covers the gesture itself in its own suite.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing?

The dependency move is one thing, but it drags three along that cannot land separately:

1. The return type. `show` had no annotation, so its type came from whatever magic-modal's `show` returned. Changing the dependency changes the public type whether or not this PR says anything about it, so it says something about it.
2. The example app's `GestureHandlerRootView`. v10's portal owns the swipe surface and needs a gesture root above it. Without this the example builds and the toasts never dismiss by swipe.
3. Snapshots. See below.

##### Snapshot diff

Both snapshots churned. jest also re-sorted the two entries, so the raw file diff pairs the alert tree against the success tree — read it per snapshot instead. The real change is the same in both:

- Named test IDs at every layer: `magic-modal-portal`, `magic-modal-stack-entry`, `magic-modal-motion-layer`, `magic-modal-animation-layer`, `magic-modal-dialog`.
- The dialog node picks up `role="dialog"`, `aria-modal`, `tabIndex={-1}` and `onAccessibilityEscape`.
- The backdrop drops out of the accessibility tree (`accessible={false}`, `aria-hidden={true}`, `importantForAccessibility="no-hide-descendants"`).
- `pointerEvents` moves from a style object onto the `pointerEvents` prop.

The `RNSFullWindowOverlay` root is still there in both, because both snapshots are taken while a toast is up. The lazy mount v10 added is only visible when nothing is showing, which these tests never snapshot, so I measured it directly on both versions — same test, same render, nothing shown:

| | root element with no toast on screen |
| --- | --- |
| v7 (`master`) | `RNSFullWindowOverlay` > `View` |
| v10 (this branch) | `View testID="magic-modal-portal"` |

So the iOS overlay is no longer mounted over the whole app while idle. Nothing in the suite pinned that, before or after.

##### Awesome tests

The two existing tests still pass and their snapshots are updated. No new test here — the export surface and its test are the next PR, and this one is a dependency move whose behaviour is what the video covers.

##### Notes

- `pnpm-workspace.yaml` gains a `minimumReleaseAgeExclude` entry for `magic-modal@10.2.0`. pnpm 11 quarantines releases younger than 24h and enforces it under `--frozen-lockfile`, so CI cannot install without it. It comes out once the package ages past the window, like the others in that list.
- No `peerDependenciesMeta`. magic-modal marks react-native, gesture-handler, reanimated, screens and worklets optional because it also ships a browser build that needs none of them. This package imports `react-native` directly, reads insets through safe-area-context, and reaches magic-modal's native entry, which statically imports `react-native-screens`. Every one of those peers is required here, and marking them optional would turn a broken install into a runtime crash.
