### PR TITLE
feat(toast): export the Toast building blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ throws `MagicModalPortal not found`. `initialMetrics={initialWindowMetrics}`,
 as above, covers iOS and Android; on web it is null and does nothing, so there
 call the toast from a component below the portal.
 
-```js
-import { magicToast } from "react-native-magic-toast";
+```jsx
+import { Toast, magicToast } from "react-native-magic-toast";
 
 // ...
 
@@ -95,6 +95,12 @@ magicToast.show(() => (
   </Toast.Container>
 ));
 ```
+
+`Toast.Container` takes every `View` prop on top of `duration`, and
+`Toast.Message` every `Text` prop, so the look is yours to override.
+`ToastContainerProps` and `ToastMessageProps` are exported for components that
+wrap them. `TOAST_TEST_ID` is the container's `testID`, for asserting a toast is
+up in tests without matching on its wording.
 
 ## The handle a toast hands back
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -3,9 +3,9 @@ import type { ModalHandle } from "magic-modal";
 import * as React from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
-import { MagicModalPortal, useMagicModal } from "magic-modal";
+import { MagicModalPortal } from "magic-modal";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { magicToast } from "react-native-magic-toast";
+import { Toast, magicToast } from "react-native-magic-toast";
 import {
   SafeAreaProvider,
   initialWindowMetrics,
@@ -20,26 +20,20 @@ const colors = {
 };
 
 /**
- * A toast built from scratch, to show what `magicToast.show` takes: any
+ * A toast of the app's own, to show what `magicToast.show` takes: any
  * component, rendered by the portal with the toast's swipe and placement.
  *
- * It runs its own timer because `Toast.Container` — the piece that owns the
- * duration — is not exported from the package yet.
+ * `Toast.Container` is the piece that owns the duration, so the toast does not
+ * need a timer of its own. Everything about the look is overridden here through
+ * ordinary `View` props.
  */
-const CustomToast = () => {
-  const { hide } = useMagicModal();
-
-  React.useEffect(() => {
-    const timeout = setTimeout(() => hide(), 3000);
-    return () => clearTimeout(timeout);
-  }, [hide]);
-
-  return (
-    <View style={styles.customToast}>
-      <Text style={styles.customToastText}>A toast of my own 🎨</Text>
-    </View>
-  );
-};
+const CustomToast = () => (
+  <Toast.Container duration={3000} style={styles.customToast}>
+    <Toast.Message style={styles.customToastText}>
+      A toast of my own 🎨
+    </Toast.Message>
+  </Toast.Container>
+);
 
 /**
  * The demo screen. `MagicModalPortal` is a sibling below it, which is fine:
@@ -148,10 +142,7 @@ const styles = StyleSheet.create({
   },
   customToast: {
     backgroundColor: colors.customToast,
-    paddingTop: 70,
-    paddingBottom: 25,
-    paddingHorizontal: 25,
-    alignItems: "center",
+    justifyContent: "center",
   },
   customToastText: {
     color: colors.customToastText,

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -10,9 +10,14 @@ import { styles } from "./styles";
 
 export const TOAST_TEST_ID = "magic-toast";
 
-type ContainerProps = {
+/** Props of {@link Toast.Container}. Every `View` prop, plus `duration`. */
+export type ToastContainerProps = {
+  /** How long the toast stays up, in milliseconds. Defaults to 3000. */
   duration?: number;
 } & ViewProps;
+
+/** Props of {@link Toast.Message}. A `Text`, styled for the toast. */
+export type ToastMessageProps = TextProps;
 
 /**
  * The container of the toast. It is responsible for hiding the toast after a
@@ -23,7 +28,10 @@ type ContainerProps = {
  *    <Toast.Message>My message</Toast.Message>
  *  </Toast.Container>
  */
-const Container: React.FC<ContainerProps> = ({ duration = 3000, ...props }) => {
+const Container: React.FC<ToastContainerProps> = ({
+  duration = 3000,
+  ...props
+}) => {
   const { top } = useSafeAreaInsets();
   const { hide } = useMagicModal();
 
@@ -48,7 +56,7 @@ const Container: React.FC<ContainerProps> = ({ duration = 3000, ...props }) => {
  *    <Toast.Message>My message</Toast.Message>
  *  </Toast.Container>
  */
-const Message: React.FC<TextProps> = (props) => (
+const Message: React.FC<ToastMessageProps> = (props) => (
   <Text {...props} style={[styles.message, props.style]} />
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,36 @@ import { alert } from "./utils/alert";
 import { show } from "./utils/show";
 import { success } from "./utils/success";
 
+export type { MagicToastProps } from "./@types/magic-toast-props";
+export type {
+  ToastContainerProps,
+  ToastMessageProps,
+} from "./components/Toast";
+
+/**
+ * The pieces a custom toast is built from.
+ *
+ * `Toast.Container` owns the duration and the placement, so a component handed
+ * to `magicToast.show` needs it to take itself off screen. `Toast.Message` is
+ * the default text style and is optional.
+ *
+ * `TOAST_TEST_ID` is the `testID` on the container, for asserting a toast is up
+ * without matching on its wording.
+ *
+ * @example
+ * ```tsx
+ * import { Toast, magicToast } from "react-native-magic-toast";
+ *
+ * magicToast.show(() => (
+ *   <Toast.Container duration={1000}>
+ *     <MyCustomIcon />
+ *     <Toast.Message>My custom toast</Toast.Message>
+ *   </Toast.Container>
+ * ));
+ * ```
+ */
+export { Toast, TOAST_TEST_ID } from "./components/Toast";
+
 export const magicToast = {
   alert,
   success,

--- a/src/public-api.test.tsx
+++ b/src/public-api.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+import { render, act } from "@testing-library/react-native";
+import { MagicModalPortal } from "magic-modal";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+
+import * as publicApi from "./index";
+import { magicToast, Toast, TOAST_TEST_ID } from "./index";
+
+/**
+ * The README has documented `Toast.Container` since the first release, and it
+ * was never exported — the example in it could not compile. These tests are
+ * here so the entry point cannot quietly lose a name again.
+ */
+describe("public API", () => {
+  it("exports exactly the documented surface", () => {
+    // Sorted, so the failure message on a change reads as a diff of names
+    // rather than of positions.
+    expect(Object.keys(publicApi).sort()).toStrictEqual([
+      "TOAST_TEST_ID",
+      "Toast",
+      "magicToast",
+    ]);
+  });
+
+  it("exposes the three toast functions", () => {
+    expect(Object.keys(magicToast).sort()).toStrictEqual([
+      "alert",
+      "show",
+      "success",
+    ]);
+  });
+
+  it("exposes the toast building blocks", () => {
+    expect(Object.keys(Toast).sort()).toStrictEqual(["Container", "Message"]);
+    expect(TOAST_TEST_ID).toBe("magic-toast");
+  });
+
+  it("renders the README's custom toast through the exported pieces", () => {
+    const component = render(
+      <SafeAreaProvider>
+        <MagicModalPortal />
+      </SafeAreaProvider>,
+    );
+
+    expect(component.queryByTestId(TOAST_TEST_ID)).toBeFalsy();
+
+    act(() => {
+      magicToast.show(() => (
+        <Toast.Container duration={1000}>
+          <Toast.Message>My custom toast</Toast.Message>
+        </Toast.Container>
+      ));
+    });
+
+    expect(component.queryByTestId(TOAST_TEST_ID)).toBeTruthy();
+    expect(component.queryByText("My custom toast")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
📝 **DESCRIPTION:**

The README has documented custom toasts built from `Toast.Container` and `Toast.Message` since the first release. Neither was exported. The snippet it tells people to copy could not compile, because `Toast` was not a name you could import from this package — the only export was `magicToast`.

- `Toast` and `TOAST_TEST_ID` are exported from `src/index.tsx`.
- `ToastContainerProps`, `ToastMessageProps` and `MagicToastProps` come with them, for components that wrap the pieces. `ContainerProps` was a local type; it is named and exported now.
- The README snippet gained the import line it was missing, plus a note on what the two components accept.
- `example/App.tsx` builds its custom toast out of `Toast.Container` instead of hand-rolling a timer with `useMagicModal`, which is what the previous PR had to do.

Nothing about the runtime changed. This is the same code, reachable.

🖼 **PRINTS & GIFS:**

No visuals. Nothing renders differently — the change is which names the entry point hands out. The proof is the test below and the built artifacts.

`lib/typescript/src/index.d.ts` after `bob build`:

```ts
export type { MagicToastProps } from "./@types/magic-toast-props";
export type { ToastContainerProps, ToastMessageProps, } from "./components/Toast";
export { Toast, TOAST_TEST_ID } from "./components/Toast";
export declare const magicToast: { ... };
```

and the CommonJS entry re-exports both at runtime, not just in types:

```js
Object.defineProperty(exports, "TOAST_TEST_ID", { enumerable: true, get: ... });
Object.defineProperty(exports, "Toast", { enumerable: true, get: ... });
```

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing?

Yes. Exports, the documentation that was already promising them, and the example that could finally stop working around their absence.

##### Awesome tests

`src/public-api.test.tsx`, four of them:

```
PASS src/public-api.test.tsx
  public API
    ✓ exports exactly the documented surface
    ✓ exposes the three toast functions
    ✓ exposes the toast building blocks
    ✓ renders the README's custom toast through the exported pieces

Test Suites: 2 passed, 2 total
Tests:       6 passed, 6 total
Snapshots:   2 passed, 2 total
```

The first pins `Object.keys` of the entry point, so removing an export fails rather than silently shipping. The last one is the regression test proper: it renders the README's example through the exported names and asserts the toast is on screen, which is exactly what nobody could do before this PR.

##### Notes

The existing snapshots are untouched — `Toast.Container` renders the same tree whether it was reached through the package entry point or a deep import.
