### PR TITLE
refactor(toast): draw the icons with views and drop react-native-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,6 @@
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "react-native-svg": "^15.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@commitlint/config-conventional": "^21.2.0",
@@ -132,7 +129,7 @@
       ]
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
     ]
   },
   "packageManager": "pnpm@11.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,10 +11,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      react-native-svg:
-        specifier: ^15.0.0
-        version: 15.15.5(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.28.0
@@ -2186,9 +2182,6 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
 
@@ -2485,17 +2478,6 @@ packages:
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
-
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
-    engines: {node: '>= 6'}
-
   cssom@0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
 
@@ -2619,23 +2601,10 @@ packages:
   dnssd-advertise@1.1.6:
     resolution: {integrity: sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==}
 
-  dom-serializer@2.0.0:
-    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
-
-  domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
-
-  domhandler@5.0.3:
-    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
-    engines: {node: '>= 4'}
-
-  domutils@3.2.2:
-    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -2668,10 +2637,6 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
-
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -3752,9 +3717,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -4013,9 +3975,6 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -4386,12 +4345,6 @@ packages:
 
   react-native-screens@4.23.0:
     resolution: {integrity: sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-
-  react-native-svg@15.15.5:
-    resolution: {integrity: sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -7668,8 +7621,6 @@ snapshots:
 
   big-integer@1.6.52: {}
 
-  boolbase@1.0.0: {}
-
   bplist-creator@0.1.0:
     dependencies:
       stream-buffers: 2.2.0
@@ -8002,21 +7953,6 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-select@5.2.2:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.2.2
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      nth-check: 2.1.1
-
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
-
-  css-what@6.2.2: {}
-
   cssom@0.3.8: {}
 
   cssom@0.5.0: {}
@@ -8109,27 +8045,9 @@ snapshots:
 
   dnssd-advertise@1.1.6: {}
 
-  dom-serializer@2.0.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
-
-  domelementtype@2.3.0: {}
-
   domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
-
-  domhandler@5.0.3:
-    dependencies:
-      domelementtype: 2.3.0
-
-  domutils@3.2.2:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
 
   dotenv@17.4.2: {}
 
@@ -8152,8 +8070,6 @@ snapshots:
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
-
-  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -9411,8 +9327,6 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdn-data@2.0.14: {}
-
   memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
@@ -9855,10 +9769,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  nth-check@2.1.1:
-    dependencies:
-      boolbase: 1.0.0
-
   nullthrows@1.1.1: {}
 
   nwsapi@2.2.24: {}
@@ -10279,13 +10189,6 @@ snapshots:
       react-freeze: 1.0.4(react@19.2.0)
       react-native: 0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       warn-once: 0.1.1
-
-  react-native-svg@15.15.5(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0):
-    dependencies:
-      css-select: 5.2.2
-      css-tree: 1.1.3
-      react: 19.2.0
-      react-native: 0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
 
   react-native-web@0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:

--- a/src/@types/icon-props.ts
+++ b/src/@types/icon-props.ts
@@ -1,0 +1,6 @@
+export type IconProps = {
+  /** Width and height of the icon's box, in pixels. Defaults per icon. */
+  size?: number;
+  /** Colour the glyph is drawn in. Defaults to the toast foreground. */
+  color?: string;
+};

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -327,57 +327,42 @@ exports[`MagicToast renders a success toast 1`] = `
               }
               testID="magic-toast"
             >
-              <RNSVGSvgView
-                align="xMidYMid"
-                bbHeight={25}
-                bbWidth={25}
-                fill="white"
-                focusable={false}
-                height={25}
-                meetOrSlice={0}
-                minX={0}
-                minY={0}
+              <View
                 style={
                   [
                     {
-                      "backgroundColor": "transparent",
-                      "borderWidth": 0,
+                      "alignItems": "center",
+                      "justifyContent": "center",
                     },
                     {
-                      "flex": 0,
                       "height": 25,
                       "width": 25,
                     },
                   ]
                 }
-                vbHeight={256}
-                vbWidth={256}
-                width={25}
               >
-                <RNSVGGroup
-                  fill={
-                    {
-                      "payload": 4294967295,
-                      "type": 0,
-                    }
-                  }
-                  propList={
+                <View
+                  style={
                     [
-                      "fill",
+                      {
+                        "transform": [
+                          {
+                            "rotate": "45deg",
+                          },
+                        ],
+                      },
+                      {
+                        "borderBottomWidth": 3,
+                        "borderColor": "white",
+                        "borderRightWidth": 3,
+                        "height": 16.5,
+                        "marginTop": -2.5,
+                        "width": 9,
+                      },
                     ]
                   }
-                >
-                  <RNSVGPath
-                    d="M128 24a104 104 0 1 0 104 104A104.11 104.11 0 0 0 128 24Zm45.66 85.66-56 56a8 8 0 0 1-11.32 0l-24-24a8 8 0 0 1 11.32-11.32L112 148.69l50.34-50.35a8 8 0 0 1 11.32 11.32Z"
-                    fill={
-                      {
-                        "payload": 4278190080,
-                        "type": 0,
-                      }
-                    }
-                  />
-                </RNSVGGroup>
-              </RNSVGSvgView>
+                />
+              </View>
               <Text
                 style={
                   [
@@ -724,59 +709,42 @@ exports[`MagicToast renders an alert toast 1`] = `
               }
               testID="magic-toast"
             >
-              <RNSVGSvgView
-                align="xMidYMid"
-                bbHeight={20}
-                bbWidth={20}
-                fill="white"
-                focusable={false}
-                height={20}
-                meetOrSlice={0}
-                minX={0}
-                minY={0}
+              <View
                 style={
                   [
                     {
-                      "backgroundColor": "transparent",
-                      "borderWidth": 0,
+                      "alignItems": "center",
+                      "justifyContent": "center",
                     },
                     {
-                      "flex": 0,
                       "height": 20,
                       "width": 20,
                     },
                   ]
                 }
-                vbHeight={512}
-                vbWidth={512}
-                width={20}
-                x="0px"
-                y="0px"
               >
-                <RNSVGGroup
-                  fill={
+                <View
+                  style={
                     {
-                      "payload": 4294967295,
-                      "type": 0,
+                      "backgroundColor": "white",
+                      "borderRadius": 1.6,
+                      "height": 9.200000000000001,
+                      "width": 3.2,
                     }
                   }
-                  propList={
-                    [
-                      "fill",
-                    ]
-                  }
-                >
-                  <RNSVGPath
-                    d="M501.362 383.95L320.497 51.474c-29.059-48.921-99.896-48.986-128.994 0L10.647 383.95c-29.706 49.989 6.259 113.291 64.482 113.291h361.736c58.174 0 94.203-63.251 64.497-113.291zM256 437.241c-16.538 0-30-13.462-30-30s13.462-30 30-30 30 13.462 30 30-13.462 30-30 30zm30-120c0 16.538-13.462 30-30 30s-30-13.462-30-30v-150c0-16.538 13.462-30 30-30s30 13.462 30 30v150z"
-                    fill={
-                      {
-                        "payload": 4278190080,
-                        "type": 0,
-                      }
+                />
+                <View
+                  style={
+                    {
+                      "backgroundColor": "white",
+                      "borderRadius": 1.6,
+                      "height": 3.2,
+                      "marginTop": 2.4,
+                      "width": 3.2,
                     }
-                  />
-                </RNSVGGroup>
-              </RNSVGSvgView>
+                  }
+                />
+              </View>
               <Text
                 style={
                   [

--- a/src/assets/alert-icon.tsx
+++ b/src/assets/alert-icon.tsx
@@ -1,11 +1,52 @@
-import type { SvgProps } from "react-native-svg";
+import type { IconProps } from "../@types/icon-props";
+
+import type { ViewStyle } from "react-native";
 
 import React from "react";
+import { StyleSheet, View } from "react-native";
 
-import { Path, Svg } from "react-native-svg";
+import { colors } from "../colors";
 
-export const AlertIcon = (props: Partial<SvgProps>) => (
-  <Svg x="0px" y="0px" viewBox="0 0 512 512" {...props}>
-    <Path d="M501.362 383.95L320.497 51.474c-29.059-48.921-99.896-48.986-128.994 0L10.647 383.95c-29.706 49.989 6.259 113.291 64.482 113.291h361.736c58.174 0 94.203-63.251 64.497-113.291zM256 437.241c-16.538 0-30-13.462-30-30s13.462-30 30-30 30 13.462 30 30-13.462 30-30 30zm30-120c0 16.538-13.462 30-30 30s-30-13.462-30-30v-150c0-16.538 13.462-30 30-30s30 13.462 30 30v150z" />
-  </Svg>
-);
+/**
+ * An exclamation mark: a rounded bar over a dot.
+ *
+ * Both are `View`s with a border radius of half their width, so the bar is a
+ * stadium and the dot a circle. Every measurement is a fraction of `size`.
+ */
+export const AlertIcon = ({
+  size = 20,
+  color = colors.foreground,
+}: IconProps) => {
+  const stroke = size * 0.16;
+
+  const box: ViewStyle = { width: size, height: size };
+
+  const bar: ViewStyle = {
+    width: stroke,
+    height: size * 0.46,
+    borderRadius: stroke / 2,
+    backgroundColor: color,
+  };
+
+  const dot: ViewStyle = {
+    width: stroke,
+    height: stroke,
+    borderRadius: stroke / 2,
+    marginTop: size * 0.12,
+    backgroundColor: color,
+  };
+
+  return (
+    <View style={[styles.box, box]}>
+      <View style={bar} />
+      <View style={dot} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  box: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/assets/success-icon.tsx
+++ b/src/assets/success-icon.tsx
@@ -1,11 +1,51 @@
-import type { SvgProps } from "react-native-svg";
+import type { IconProps } from "../@types/icon-props";
+
+import type { ViewStyle } from "react-native";
 
 import React from "react";
+import { StyleSheet, View } from "react-native";
 
-import { Path, Svg } from "react-native-svg";
+import { colors } from "../colors";
 
-export const SuccessIcon = (props: Partial<SvgProps>) => (
-  <Svg viewBox="0 0 256 256" {...props}>
-    <Path d="M128 24a104 104 0 1 0 104 104A104.11 104.11 0 0 0 128 24Zm45.66 85.66-56 56a8 8 0 0 1-11.32 0l-24-24a8 8 0 0 1 11.32-11.32L112 148.69l50.34-50.35a8 8 0 0 1 11.32 11.32Z" />
-  </Svg>
-);
+/**
+ * A check mark.
+ *
+ * It is one `View` with two of its four borders drawn, turned 45°: the right
+ * and bottom edges of a box become the short and long strokes of a tick. Every
+ * measurement is a fraction of `size`, so the stroke stays in proportion at any
+ * size.
+ */
+export const SuccessIcon = ({
+  size = 25,
+  color = colors.foreground,
+}: IconProps) => {
+  const box: ViewStyle = { width: size, height: size };
+
+  const tick: ViewStyle = {
+    width: size * 0.36,
+    height: size * 0.66,
+    // Rotating about the centre of the box leaves the tick sitting low, since
+    // the stroke only occupies two of the four edges. This lifts it back onto
+    // the optical centre.
+    marginTop: -size * 0.1,
+    borderColor: color,
+    borderRightWidth: size * 0.12,
+    borderBottomWidth: size * 0.12,
+  };
+
+  return (
+    <View style={[styles.box, box]}>
+      <View style={[styles.tick, tick]} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  box: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tick: {
+    transform: [{ rotate: "45deg" }],
+  },
+});

--- a/src/components/alert-toast.tsx
+++ b/src/components/alert-toast.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import { StatusBar } from "react-native";
 
 import { AlertIcon } from "../assets/alert-icon";
-import { colors } from "../colors";
 import { Toast } from "./Toast";
 
 export const AlertToast: React.FC<MagicToastProps> = ({
@@ -14,7 +13,7 @@ export const AlertToast: React.FC<MagicToastProps> = ({
   return (
     <Toast.Container duration={duration}>
       <StatusBar barStyle="light-content" />
-      <AlertIcon fill={colors.foreground} width={20} height={20} />
+      <AlertIcon size={20} />
       <Toast.Message>{message}</Toast.Message>
     </Toast.Container>
   );

--- a/src/components/success-toast.tsx
+++ b/src/components/success-toast.tsx
@@ -14,7 +14,7 @@ export const SuccessToast: React.FC<MagicToastProps> = ({
   return (
     <Toast.Container style={styles.container} duration={duration}>
       <StatusBar barStyle="light-content" />
-      <SuccessIcon fill={colors.foreground} width={25} height={25} />
+      <SuccessIcon size={25} />
       <Toast.Message>{message}</Toast.Message>
     </Toast.Container>
   );


### PR DESCRIPTION
📝 **DESCRIPTION:**

Both icons were a single `Path` in an 11-line file. Carrying react-native-svg for them meant every consumer of this package installed a native module, linked a pod and compiled RNSVG — to draw a tick and an exclamation mark.

They are plain `View`s now:

- **Tick**: one view with its right and bottom borders drawn, turned 45°. The two edges of a box become the two strokes of a check.
- **Exclamation**: a rounded bar over a dot, both views with a border radius of half their width.

Every measurement is a fraction of `size`, so the stroke stays in proportion at any size. `react-native-svg` is out of `dependencies` and out of the jest `transformIgnorePatterns` entry that existed only to let it through.

🖼 **PRINTS & GIFS:**

Simulator, iPhone 17 Pro, iOS 26.5, Release build of `example/App.tsx`. Top row is `master`, bottom row is this branch, same toast and same flow both times.

| Alert toast | Success toast |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr20-alert-before-after.png" width="380"/> | <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr20-success-before-after.png" width="380"/> |

**Read this before approving: the enclosing shapes are gone.** The old tick sat in a filled white disc and the old exclamation sat in a filled white triangle, both of them knocked out of the shape rather than drawn. The new ones are the glyphs alone, at the same weight and position.

That is deliberate rather than a limitation I hit. A knockout needs a hole the toast's background shows through, and a `View` cannot have one — the alternative is painting the "hole" in a hardcoded background colour, which breaks the moment somebody restyles `Toast.Container`, and restyling it is documented and supported. Drawing the glyph in the foreground colour works on any background.

I also ran the whole capture again under iOS dark appearance:

| Alert (dark appearance) | Success (dark appearance) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr20-after-alert-darkmode.png" width="380"/> | <img src="https://raw.githubusercontent.com/GSTJ/react-native-magic-toast/evidence/pr-videos/evidence/pr20-after-success-darkmode.png" width="380"/> |

They are the same images. Measured rather than eyeballed: light against dark is 61.5 dB PSNR on the alert strip and 59.8 dB on the success strip, which at that level is h264 noise and nothing else. The toast paints its own opaque background, so system appearance never reaches the icons. Worth knowing rather than assuming.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing?

Yes — the drawing of two icons, and the dependency that existed for them.

The icon props changed shape as a consequence: `fill`/`width`/`height` were `SvgProps`, and there is no `SvgProps` any more. They take `{ size?, color? }` now, with `color` defaulting to the toast foreground. Neither icon is exported from the package, so this is internal.

##### Awesome tests

The existing snapshots cover it, and the diff is the point: every `RNSVGSvgView` / `RNSVGGroup` / `RNSVGPath` node is replaced by `View`s with the computed styles, and nothing else in either tree moves.

```diff
-              <RNSVGSvgView align="xMidYMid" bbHeight={25} bbWidth={25} fill="white" ...>
-                <RNSVGGroup fill={{"payload": 4294967295, "type": 0}} propList={["fill"]}>
-                  <RNSVGPath d="M128 24a104 104 0 1 0 104 104A104.11 104.11 0 0 0 128 24Zm45.66..." />
-                </RNSVGGroup>
-              </RNSVGSvgView>
+              <View style={[{"alignItems": "center", "justifyContent": "center"}, {"height": 25, "width": 25}]}>
+                <View style={[{"transform": [{"rotate": "45deg"}]},
+                              {"borderBottomWidth": 3, "borderColor": "white", "borderRightWidth": 3,
+                               "height": 16.5, "marginTop": -2.5, "width": 9}]} />
+              </View>
```

Full suite, 6 tests over 2 files, green with the two snapshots updated.

##### The dependency actually leaves

Not just the manifest. `pnpm install` drops it from the lockfile and the tree, and the first Release build after that **failed**, which is the useful part:

```
❌  error: Build input file cannot be found: '.../node_modules/react-native-svg/apple/Utils/RCTConvert+RNSVG.mm'
    (in target 'RNSVG' from project 'Pods')
```

The pod was still integrated from the previous build. Re-running `pnpm run pods` took `RNSVG` from 6 references in `Podfile.lock` to 0 — 89 dependencies, 88 pods installed — and the build went green. So this removes a compiled native target from consumer apps, not just a line in package.json.
