### PR TITLE
fix(packaging): add an exports map and drop the phantom native entries

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -1,10 +1,12 @@
 module.exports = function (api) {
   api.cache(true);
 
-  // The example depends on the library as `workspace:*`, so pnpm links it into
-  // `example/node_modules`. Metro then reads the root `package.json`, whose
-  // `react-native` field already points at `src`. That is what the
-  // `module-resolver` alias used to do by hand.
+  // The example imports the library by name and gets `../src`, so an edit shows
+  // up on the next reload without a build. That comes from the `paths` entry in
+  // `tsconfig.json`, which Expo's Metro config reads and applies before it looks
+  // in `node_modules` — measured by dropping the entry and watching resolution
+  // move to `lib/module/index.js`. It is what the `module-resolver` alias used
+  // to do by hand.
   return {
     presets: ["babel-preset-expo"],
   };

--- a/package.json
+++ b/package.json
@@ -13,28 +13,33 @@
   },
   "license": "MIT",
   "author": "Gabriel Taveira <gabrielstaveira@gmail.com> (https://github.com/GSTJ)",
-  "repository": "https://github.com/GSTJ/react-native-magic-toast",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GSTJ/react-native-magic-toast.git"
+  },
   "source": "src/index",
   "files": [
-    "src",
     "lib",
-    "android",
-    "ios",
-    "cpp",
-    "react-native-magic-toast.podspec",
-    "!lib/typescript/example",
-    "!android/build",
-    "!ios/build",
-    "!**/__tests__",
-    "!**/__fixtures__",
-    "!**/__mocks__",
-    "!**/__snapshots__",
-    "!**/*.test.*"
+    "!lib/**/*.d.ts.map"
   ],
-  "main": "lib/commonjs/index",
-  "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
-  "react-native": "src/index",
+  "type": "commonjs",
+  "sideEffects": false,
+  "main": "./lib/commonjs/index.js",
+  "module": "./lib/module/index.js",
+  "types": "./lib/typescript/commonjs/src/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./lib/typescript/module/src/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "require": {
+        "types": "./lib/typescript/commonjs/src/index.d.ts",
+        "default": "./lib/commonjs/index.js"
+      }
+    }
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
@@ -138,8 +143,20 @@
     "output": "lib",
     "exclude": "**/{__tests__/**,__fixtures__/**,__mocks__/**,__snapshots__/**,*.test.*,*.spec.*}",
     "targets": [
-      "commonjs",
-      "module",
+      [
+        "commonjs",
+        {
+          "esm": true,
+          "sourceMaps": false
+        }
+      ],
+      [
+        "module",
+        {
+          "esm": true,
+          "sourceMaps": false
+        }
+      ],
       [
         "typescript",
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/react': ~19.2.14
   uuid: ^11.1.1
+  brace-expansion@1: ^1.1.17
 
 importers:
 
@@ -2193,8 +2194,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -7633,7 +7634,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -9716,7 +9717,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,14 @@ dedupeDirectDeps: true
 overrides:
   "@types/react": "~19.2.14"
   "uuid": "^11.1.1"
+  # GHSA-mh99-v99m-4gvg / CVE-2026-14257. jest's glob@7 and test-exclude@6 pull
+  # minimatch@3, which pins brace-expansion@1, and 1.1.16 is the vulnerable one.
+  # The fix landed in 1.1.17 and caps how many characters a single `expand()`
+  # may accumulate; nothing under that cap behaves differently, and a glob
+  # pattern that would reach 4M characters of output is not one jest is passing.
+  # Scoped to the 1.x range because the tree also carries brace-expansion@5,
+  # which is already past its own patched version.
+  "brace-expansion@1": "^1.1.17"
 
 # pnpm 11 quarantines releases younger than 24h and enforces it on
 # `--frozen-lockfile`, so CI cannot install these without the exemption.

--- a/tools/changelog-preset.mjs
+++ b/tools/changelog-preset.mjs
@@ -2,25 +2,25 @@
 // ships.
 //
 // The stock preset renders feat, fix, perf and reverts and hides everything
-// else, which is wrong for a package whose `files` field publishes `src/` and
-// `lib/` side by side. A `refactor:` here rewrites both. A `chore(deps):` moves
-// the dependency tree a consumer installs. Hiding those leaves releases that
-// changed the tarball described by an empty section.
+// else, which is wrong for a package that publishes compiled output. A
+// `refactor:` in `src/` is a rewrite of every file in `lib/`. A `chore(deps):`
+// moves the dependency tree a consumer installs. Hiding those leaves releases
+// that changed the tarball described by an empty section.
 //
 // The split is by whether a type can change what npm hands a consumer:
 //
 //   renders   feat fix perf revert   the stock set
 //             build                  bob's targets and tsconfig.build.json
 //                                    decide what lands in lib/
-//             refactor               rewrites src/ and lib/, both published
+//             refactor               rewrites src/, and lib/ is compiled from it
 //             chore                  dependency and config moves ship
 //             docs                   README.md is inside the tarball
 //
 //   hidden    ci                     .github/ is not in `files`
-//             style                  oxfmt does touch published src/, but only
+//             style                  oxfmt reaches lib/ through src/, but only
 //                                    its whitespace — nothing a consumer can
 //                                    observe at runtime or in types
-//             test                   `!**/__tests__` is excluded from `files`
+//             test                   bob's `exclude` keeps tests out of lib/
 //
 // `effect: "changelog"` is the important part: it renders the type without
 // letting it drive the version bump, so a pile of `build:` commits still adds


### PR DESCRIPTION
📝 **DESCRIPTION:**

Three things, all of them about what npm hands a consumer.

**The phantom entries.** `files` listed `android`, `ios`, `cpp` and `react-native-magic-toast.podspec`, plus `!android/build`, `!ios/build` and `!lib/typescript/example` to carve holes in them. None of those paths have ever existed in this repo. They matched nothing, so the tarball was already right — the list was describing a different package, one with native code. It says `lib` now.

**The exports map.** This is the part that changes behaviour. There was no `exports` field, so Node resolving `import "react-native-magic-toast"` from an ESM file walked the legacy `main` into `lib/commonjs`. The ESM build was published on every release and loaded by nobody. publint said so, once per file:

```
2. /lib/module/colors.js is written in ESM, but is interpreted as CJS. Consider using the .mjs extension
3. /lib/module/index.js is written in ESM, but is interpreted as CJS. Consider using the .mjs extension
... 11 of these
```

It was literally true: `lib/module/*.js` is `import`/`export` syntax, and nothing marked that directory as ESM — no `type` field at the root, no `package.json` inside it. Adding an `exports` map on its own would have made that worse, not better, because then the `import` condition would have pointed Node at ESM files it was still required to parse as CommonJS. bob knows this and warns about it directly (`utils/compile.js`): *"The `esm` option is disabled, but the `exports['.'].require` field is set in package.json. This is likely a mistake."*

So `esm: true` goes on bob's `commonjs` and `module` targets first. That writes `{"type": "commonjs"}` and `{"type": "module"}` into the two output directories, rewrites the module build's relative imports to carry `.js`, and splits the declarations into `lib/typescript/commonjs` and `lib/typescript/module` so each side gets declarations whose own imports resolve under its own rules. The map is then the shape bob's `init` generates for that target set, verbatim.

**`src` stops shipping.** It was in `files` to back the `react-native` field, which pointed at `src/index` so Metro would compile the TSX in a consumer's app. bob's `init` offers to delete that field on sight, and gives the reason: pointing consumers at source breaks the moment they customise their babel config. Both are gone. Source maps go with them — bob writes `sourceRoot: "../../src"` into every `.js.map` and `.d.ts.map`, so with `src` out of the tarball all 41 of them pointed at a directory that isn't there. `sourceMaps: false` on the two babel targets kills the `.js.map`s; bob hardcodes `--declarationMap` on the tsc call, so the `.d.ts.map`s are dropped through `files`.

🖼 **PRINTS & GIFS:**

### `npm pack --dry-run`, before and after

Both packed from a built tree at the same commit content, `master` on the left.

```
before   100 files   20.4 kB packed   80.1 kB unpacked
after     61 files   12.1 kB packed   49.6 kB unpacked
```

```
removed   src/**                    14
          lib/**/*.js.map           28
          lib/**/*.d.ts.map         13
          lib/typescript/**         13   (moved, see below)
added     lib/typescript/**         28   (one set per module system)
          lib/module/package.json    1
```

The typescript directory doubling is the cost of the change and it is not hidden: `lib/typescript/src/*` becomes `lib/typescript/commonjs/src/*` and `lib/typescript/module/src/*`, because the module build's declarations need `.js` on their relative imports and the commonjs build's need them absent. 41 % off the packed tarball after paying for it.

### publint

<table>
<tr><th>before</th><th>after</th></tr>
<tr valign="top"><td>

```
Warnings:
1. pkg.repository is https://github.com/GSTJ/react-native-magic-toast
   which isn't a valid shorthand value supported by npm.
2. /lib/module/colors.js is written in ESM, but is
   interpreted as CJS.
3. /lib/module/index.js ... (same, ×10 more)
Suggestions:
1. The package does not specify the "type" field.
2. The package ... does not specify "sideEffects".
3. The package does not specify the "engines.node" field.
```

</td><td>

```
Suggestions:
1. The package does not specify the "engines.node" field.
   Consumers may install it on an unsupported Node.js
   version. (This may be a breaking change)
```

</td></tr>
</table>

`repository` is an object now, `type` and `sideEffects` are set. `engines.node` is the one suggestion left and publint flags it as possibly breaking; this package runs wherever Metro runs and I would rather not invent a floor to satisfy a linter.

### attw

Green both times, and the interesting cell is the third row.

<table>
<tr><th>before</th><th>after</th></tr>
<tr valign="top"><td>

```
node10             🟢
node16 (from CJS)  🟢 (CJS)
node16 (from ESM)  🟢 (CJS)
bundler            🟢
```

</td><td>

```
                   "…/package.json"   "…"
node10             🟢 (JSON)          🟢
node16 (from CJS)  🟢 (JSON)          🟢 (CJS)
node16 (from ESM)  🟢 (JSON)          🟢 (ESM)
bundler            🟢 (JSON)          🟢
```

</td></tr>
</table>

`🟢 (CJS)` on the ESM row was attw saying the types were consistent, not that the resolution was what anyone wanted.

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

Packaging, in the sense of what the tarball contains and how it resolves. The `brace-expansion` bump is the exception and is called out below.

Two comments changed because this made them wrong:

- `example/babel.config.js` said the example resolves the library through the root `react-native` field. It doesn't, and it didn't before either — it's the `paths` entry in `example/tsconfig.json`, which Expo's Metro config applies ahead of `node_modules`. Measured: with that entry removed, resolution moves to `lib/module/index.js`.
- `tools/changelog-preset.mjs` justified rendering `refactor:` and `style:` by "`files` publishes `src/` and `lib/` side by side". It doesn't any more. The conclusion is unchanged — `lib/` is compiled from `src/`, so a refactor still rewrites everything published — so only the reasoning was rewritten.

##### Awesome tests or e2e (avoid `shallow` rendering)

Existing suite green, 6 tests over 2 files, no snapshot churn — nothing in `src/` moved.

The claims above are about the tarball, so they were checked against the tarball. `npm pack` output installed into a scratch project with the five peer imports stubbed (`react-native`, `react-native-safe-area-context`, `magic-modal`, `react`, `react/jsx-runtime`), then loaded both ways. Same tests, old tarball and new:

```
BEFORE, require:  lib/commonjs/index.js   TOAST_TEST_ID, Toast, magicToast
BEFORE, import:   lib/commonjs/index.js   TOAST_TEST_ID, Toast, __esModule, default, magicToast, module.exports
AFTER,  require:  lib/commonjs/index.js   TOAST_TEST_ID, Toast, magicToast
AFTER,  import:   lib/module/index.js     TOAST_TEST_ID, Toast, magicToast
```

Both entry points execute, not just resolve — `magicToast` is `{alert, show, success}` and `Toast` is `{Container, Message}` in all four runs. The before/import row is the bug: an ESM consumer got the CommonJS build and its interop artifacts hanging off the namespace.

And because the map has to survive Metro, not just Node: the packed tarball was dropped into `example/node_modules` under a second name and imported from the example's entry. Metro resolves it to `lib/module/index.js` and the iOS bundle builds, 1092 modules, no `Falling back to file-based resolution` warning. Metro's condition set is `default` + `require`/`import` + `react-native`, so both branches of the map are reachable; that was read out of `metro-resolver/src/utils/matchSubpathFromExportsLike.js` and then confirmed by bundling.

##### Anything else

**This is the release that ships the icon rewrite.** `refactor(toast): draw the icons with views and drop react-native-svg` (#20) merged after `v1.2.0` was cut, and `refactor` doesn't bump on its own, so it has been sitting on master unpublished — `tools/release-plan.mjs` on master right now says `release=false`. This `fix` bumps to 1.2.1 and takes it along, and 1.2.1's changelog will carry both entries. The published tarball stops depending on `react-native-svg` at that release, not before.

**Dependabot.** Alert #200, `brace-expansion`, HIGH, GHSA-mh99-v99m-4gvg — unbounded expansion length, OOM crash. Transitive and development-scoped: `jest` → `glob@7` / `test-exclude@6` → `minimatch@3` → `brace-expansion@1.1.16`. The advisory patches `<1.1.17` at 1.1.17; the tree's other copy is already 5.0.8, which is past its own fix. A `brace-expansion@1: ^1.1.17` pnpm override resolves to 1.1.18 and touches nothing else in the lockfile. The fix caps the characters one `expand()` may accumulate at 4M, so nothing that isn't already an attack changes behaviour, and none of this reaches a consumer — jest is not in the tarball.

Worth knowing: GitHub had already auto-dismissed it (23 minutes after opening, by the dev-scope auto-triage rule), so it does not show up as open. It is fixed here anyway because the cost was one line.
