### PR TITLE
ci(security): pin GitHub Actions to immutable commits

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -17,7 +17,7 @@ jobs:
   # Lint, format and typecheck come from the shared workflow in GSTJ/magic.
   # Node version is read from .nvmrc and pnpm from the `packageManager` field.
   checkup:
-    uses: GSTJ/magic/.github/workflows/ci.yml@v1
+    uses: GSTJ/magic/.github/workflows/ci.yml@aa331e83282c2794edd474646c671f036dfabee0 # v1
     with:
       # `pnpm install` already runs `prepare`, which is `bob build`. Running it
       # again is what fails the job if the build breaks.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   # runs that workflow, so this is where a push to master gets checked, and the
   # release below cannot start until it passes.
   checkup:
-    uses: GSTJ/magic/.github/workflows/ci.yml@v1
+    uses: GSTJ/magic/.github/workflows/ci.yml@aa331e83282c2794edd474646c671f036dfabee0 # v1
     with:
       build-command: pnpm run build
       test-command: pnpm test
@@ -44,13 +44,13 @@ jobs:
       version: ${{ steps.plan.outputs.version }}
     steps:
       - name: 🏗 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # The plan reads every tag and every commit since the last one.
           fetch-depth: 0
 
       - name: 🏗 Setup Node + pnpm
-        uses: GSTJ/magic/.github/actions/setup@v1
+        uses: GSTJ/magic/.github/actions/setup@aa331e83282c2794edd474646c671f036dfabee0 # v1
 
       - name: 🧾 Plan the release
         id: plan
@@ -59,7 +59,7 @@ jobs:
   release:
     needs: [checkup, plan]
     if: needs.plan.outputs.release == 'true'
-    uses: GSTJ/magic/.github/workflows/release.yml@v1
+    uses: GSTJ/magic/.github/workflows/release.yml@aa331e83282c2794edd474646c671f036dfabee0 # v1
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

The release and pull-request checks now execute the same reviewed code on every run.

## Details

- Keeps `actions/checkout` on v7.0.1 while preventing tag retargeting from changing the release job.
- Keeps the shared GSTJ/magic CI, setup, and release behavior on v1 at commit `aa331e83282c2794edd474646c671f036dfabee0`.
- Fixes the CodeQL `actions/unpinned-tag` alert raised by extended scanning.

## Testing steps

1. Run:

```sh
actionlint
pnpm run format
pnpm run lint
pnpm run typecheck
pnpm test --runInBand
pnpm run build
pnpm run changelog:check
```

2. Confirm every command exits successfully and the test run reports six passing tests.
3. Open the PR checks and confirm the branch checkup and CodeQL jobs pass with the pinned workflows.
