### PR TITLE
chore(security): patch audit findings

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -17,7 +17,7 @@ jobs:
   # Lint, format and typecheck come from the shared workflow in GSTJ/magic.
   # Node version is read from .nvmrc and pnpm from the `packageManager` field.
   checkup:
-    uses: GSTJ/magic/.github/workflows/ci.yml@aa331e83282c2794edd474646c671f036dfabee0 # v1
+    uses: GSTJ/magic/.github/workflows/ci.yml@4c640f094849d988c7380e1512f87c46a5408515 # v1.12.3
     with:
       # `pnpm install` already runs `prepare`, which is `bob build`. Running it
       # again is what fails the job if the build breaks.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   # runs that workflow, so this is where a push to master gets checked, and the
   # release below cannot start until it passes.
   checkup:
-    uses: GSTJ/magic/.github/workflows/ci.yml@aa331e83282c2794edd474646c671f036dfabee0 # v1
+    uses: GSTJ/magic/.github/workflows/ci.yml@4c640f094849d988c7380e1512f87c46a5408515 # v1.12.3
     with:
       build-command: pnpm run build
       test-command: pnpm test
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: 🏗 Setup Node + pnpm
-        uses: GSTJ/magic/.github/actions/setup@aa331e83282c2794edd474646c671f036dfabee0 # v1
+        uses: GSTJ/magic/.github/actions/setup@4c640f094849d988c7380e1512f87c46a5408515 # v1.12.3
 
       - name: 🧾 Plan the release
         id: plan
@@ -59,7 +59,7 @@ jobs:
   release:
     needs: [checkup, plan]
     if: needs.plan.outputs.release == 'true'
-    uses: GSTJ/magic/.github/workflows/release.yml@aa331e83282c2794edd474646c671f036dfabee0 # v1
+    uses: GSTJ/magic/.github/workflows/release.yml@4c640f094849d988c7380e1512f87c46a5408515 # v1.12.3
     permissions:
       contents: write
       id-token: write

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm exec commitlint -E HUSKY_GIT_PARAMS
+pnpm exec commitlint --edit "$1"

--- a/example/app.json
+++ b/example/app.json
@@ -1,6 +1,4 @@
 {
-  "name": "react-native-magic-toast-example",
-  "displayName": "MagicToast Example",
   "expo": {
     "name": "react-native-magic-toast-example",
     "slug": "react-native-magic-toast-example",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint": "oxlint --report-unused-disable-directives",
     "lint:fix": "oxlint --report-unused-disable-directives --fix",
     "pods": "pnpm --filter react-native-magic-toast-example exec pod-install --quiet",
-    "prepare": "bob build",
+    "prepare": "bob build && husky",
     "release": "release-it",
     "test": "jest",
     "typecheck": "tsc --noEmit"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,9 @@ settings:
 overrides:
   '@types/react': ~19.2.14
   uuid: ^11.1.1
-  brace-expansion@1: ^1.1.17
+  brace-expansion@1: ^1.1.18
+  brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
+  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
 
 importers:
 
@@ -2197,8 +2199,8 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2835,8 +2837,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -7389,7 +7391,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7639,7 +7641,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8277,7 +8279,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -9713,7 +9715,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,23 +12,9 @@ dedupeDirectDeps: true
 overrides:
   "@types/react": "~19.2.14"
   "uuid": "^11.1.1"
-  # GHSA-mh99-v99m-4gvg / CVE-2026-14257. jest's glob@7 and test-exclude@6 pull
-  # minimatch@3, which pins brace-expansion@1, and 1.1.16 is the vulnerable one.
-  # The fix landed in 1.1.17 and caps how many characters a single `expand()`
-  # may accumulate; nothing under that cap behaves differently, and a glob
-  # pattern that would reach 4M characters of output is not one jest is passing.
-  # Scoped to the 1.x range because the tree also carries brace-expansion@5,
-  # which is already past its own patched version.
-  "brace-expansion@1": "^1.1.17"
-
-# pnpm 11 quarantines releases younger than 24h and enforces it on
-# `--frozen-lockfile`, so CI cannot install these without the exemption.
-# Delete each entry once the package ages past the window.
-minimumReleaseAgeExclude:
-  - eslint-plugin-safe-jsx@1.3.5
-  - magic-codemods@1.1.0
-  - magic-modal@10.2.0
-  - magic-oxfmt-config@1.2.0
-  - magic-oxlint-config@2.0.0
-  - magic-oxlint-plugin@1.2.0
-  - magic-tsconfig@1.2.0
+  # GHSA-rgw5-rvv9-x895. Both brace-expansion branches in the tree need their
+  # bounded expansion fix. The 5.0.8 fix for the earlier advisory was incomplete.
+  "brace-expansion@1": "^1.1.18"
+  "brace-expansion@>=4.0.0 <5.0.9": "^5.0.9"
+  # GHSA-7p8r-x3mc-p8w7. commitlint reaches fast-uri through ajv.
+  "fast-uri@>=3.0.0 <3.1.5": "^3.1.5"


### PR DESCRIPTION
## Summary

Updates two vulnerable transitive packages and fixes the workflow and commit-message checks.

## Details

- Forces `brace-expansion` 5.0.9 and `fast-uri` 3.1.5, clearing GHSA-rgw5-rvv9-x895 and GHSA-7p8r-x3mc-p8w7 from the workspace.
- Updates the shared workflows to v1.12.3.
  - `4c640f094849d988c7380e1512f87c46a5408515` - the release commit used by every reusable call.
  - `contents: read` - limits the CI token to reading repository content.
  - `pull-requests: write` - removed from the release job.
- Installs Husky with the rest of the repository and gives commitlint the message file passed by Husky 9.
- Removes expired pnpm release-age exemptions and the root Expo fields that its config loader ignored.
- Runtime code and generated JS and types are unchanged. The release planner sees a chore-only commit and returns no release. npm remains at 1.2.1.

## Testing steps

1. Install dependencies, audit them, and run the tests:

   ```sh
   pnpm install --frozen-lockfile
   pnpm audit --audit-level low
   pnpm test
   ```

   The audit should report no known vulnerabilities and the tests should pass.

2. Check the commit hook and release decision:

   ```sh
   git config --get core.hooksPath
   message_file=$(mktemp)
   printf 'not conventional\n' > "$message_file"
   if sh .husky/commit-msg "$message_file"; then exit 1; else echo "invalid message rejected"; fi
   rm "$message_file"
   node tools/release-plan.mjs
   ```

   The first command should print a configured hook directory, the sample message should be rejected, and the planner should say there is nothing to release.

3. Build the example for each supported platform:

   ```sh
   pnpm --filter react-native-magic-toast-example exec expo export --platform ios
   pnpm --filter react-native-magic-toast-example exec expo export --platform android
   pnpm --filter react-native-magic-toast-example exec expo export --platform web
   ```

   Each export should finish with an exported bundle and no ignored-config warning.

4. Open the pull request's Checks tab and confirm Branch Checkup completes successfully.
