### PR TITLE
chore(deps): let first-party magic packages update immediately

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,10 +5,12 @@ packages:
 # to direct and transitive dependencies, including frozen-lockfile installs.
 minimumReleaseAge: 20160
 minimumReleaseAgeExclude:
-  # These exact versions were already present on main on 2026-08-04, before
-  # the floor existed.
-  # The exclusions keep that lockfile installable without exempting later
-  # releases.
+  # GSTJ owns the source and publish path for the magic-* packages, so they can
+  # move immediately with the matching Renovate rule.
+  - "magic-*"
+  # These exact third-party versions were already present on main on
+  # 2026-08-04, before the floor existed. The exclusions keep that lockfile
+  # installable without exempting later releases.
   - "@react-native/babel-plugin-codegen@0.86.1"
   - "@react-native/babel-preset@0.86.1"
   - "@react-native/codegen@0.86.1"
@@ -26,12 +28,6 @@ minimumReleaseAgeExclude:
   - "fs-extra@11.4.0"
   - "giget@3.3.1"
   - "ip-address@10.3.1"
-  - "magic-codemods@1.1.0"
-  - "magic-modal@10.2.0"
-  - "magic-oxfmt-config@1.2.0"
-  - "magic-oxlint-config@2.0.0"
-  - "magic-oxlint-plugin@1.2.0"
-  - "magic-tsconfig@1.2.0"
   - "postcss@8.5.23"
   - "release-it@21.0.0"
   - "sax@1.6.1"


### PR DESCRIPTION
## Summary

The pnpm release-age policy now lets GSTJ's `magic-*` packages update immediately, matching the shared Renovate preset.

## Details

- Replaces six exact `magic-*` exclusions with the package-name pattern used by magic v1.12.5.
- Keeps the 22 exact third-party grandfather entries. Future third-party releases still wait 14 days.

## Testing steps

1. Check out this branch.
2. Run:

```sh
corepack pnpm install --frozen-lockfile --ignore-scripts
corepack pnpm audit
corepack pnpm run build
corepack pnpm run lint
corepack pnpm run format
corepack pnpm run typecheck
corepack pnpm test
corepack pnpm run changelog:check
npm pack --dry-run
```

3. Confirm the install reports that the lockfile passes the supply-chain policy and every command exits successfully.

![Local checks](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/d367c6b8d5f67589a5aa21ae13fe02b1bbd3397e/evidence/react-native-magic-toast/first-party-release-age-proof.png)
