### PR TITLE
chore(security): patch September dependency advisories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ name: 🚀 Release
 on:
   push:
     branches: [master]
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ with a duplicate native module. See the
 
 * release 0.2.1 ([c58904d](https://github.com/GSTJ/react-native-magic-toast/commit/c58904da56aa68a08ebf9c1e3ebd2213fab93f1d))
 
-## [0.2.0](https://github.com/GSTJ/react-native-magic-toast/compare/v0.1.3...v0.2.0) (2023-08-21)
+## [0.2.0](https://github.com/GSTJ/react-native-magic-toast/compare/v0.1.4...v0.2.0) (2023-08-21)
 
 ### Features
 
@@ -154,9 +154,18 @@ with a duplicate native module. See the
 
 ### Documentation
 
+* update README.md ([48a59a2](https://github.com/GSTJ/react-native-magic-toast/commit/48a59a29c3218b838a36e93ec7ac25a2956576f2))
+
+## [0.1.4](https://github.com/GSTJ/react-native-magic-toast/compare/v0.1.3...v0.1.4) (2023-08-21)
+
+### Chores
+
+* release 0.1.4 ([5ee2916](https://github.com/GSTJ/react-native-magic-toast/commit/5ee2916539a7e78594c0d16480354ced60360d2f))
+
+### Documentation
+
 * update readme.md ([760d8ce](https://github.com/GSTJ/react-native-magic-toast/commit/760d8ce0b6a8233534abfeffbe6bdbb40e2ba9d2))
 * update readme.md ([63eb743](https://github.com/GSTJ/react-native-magic-toast/commit/63eb7439de44ebdd1000e036fdf8749e0d3e963b))
-* update README.md ([48a59a2](https://github.com/GSTJ/react-native-magic-toast/commit/48a59a29c3218b838a36e93ec7ac25a2956576f2))
 
 ## [0.1.3](https://github.com/GSTJ/react-native-magic-toast/compare/v0.1.2...v0.1.3) (2022-02-22)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,11 @@ settings:
 overrides:
   '@types/react': ~19.2.14
   uuid: ^11.1.1
+  '@xmldom/xmldom@>=0.7.0 <0.8.15': ^0.8.15
+  '@xmldom/xmldom@>=0.9.0 <0.9.12': ^0.9.12
   brace-expansion@1: ^1.1.18
   brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
-  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
+  fast-uri@>=3.0.0 <3.1.6: ^3.1.6
   js-yaml@3: ^3.15.1
   js-yaml@4: ^4.3.1
   nanoid@3: ^3.3.18
@@ -1954,12 +1956,12 @@ packages:
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
 
   abab@2.0.6:
@@ -2843,8 +2845,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6385,7 +6387,7 @@ snapshots:
 
   '@expo/plist@0.5.4':
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -7353,9 +7355,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   abab@2.0.6: {}
 
@@ -7397,7 +7399,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8285,7 +8287,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -10018,7 +10020,7 @@ snapshots:
 
   plist@3.1.1:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,6 @@ minimumReleaseAgeExclude:
   - "electron-to-chromium@1.5.396"
   - "es-toolkit@1.50.0"
   - "eslint-plugin-safe-jsx@1.3.5"
-  - "fast-uri@3.1.5"
   - "fs-extra@11.4.0"
   - "giget@3.3.1"
   - "ip-address@10.3.1"
@@ -60,12 +59,16 @@ dedupeDirectDeps: true
 overrides:
   "@types/react": "~19.2.14"
   "uuid": "^11.1.1"
+  # GHSA-6gmq-8vp8-gcm6. Expo's plist tooling reaches both maintained xmldom lines.
+  "@xmldom/xmldom@>=0.7.0 <0.8.15": "^0.8.15"
+  "@xmldom/xmldom@>=0.9.0 <0.9.12": "^0.9.12"
   # GHSA-rgw5-rvv9-x895. Both brace-expansion branches in the tree need their
   # bounded expansion fix. The 5.0.8 fix for the earlier advisory was incomplete.
   "brace-expansion@1": "^1.1.18"
   "brace-expansion@>=4.0.0 <5.0.9": "^5.0.9"
-  # GHSA-7p8r-x3mc-p8w7. commitlint reaches fast-uri through ajv.
-  "fast-uri@>=3.0.0 <3.1.5": "^3.1.5"
+  # GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf and
+  # GHSA-jqff-g426-hqxp. commitlint reaches fast-uri through ajv.
+  "fast-uri@>=3.0.0 <3.1.6": "^3.1.6"
   # GHSA-5p4m-2wfm-xmqj. Jest and Expo reach both maintained js-yaml lines.
   "js-yaml@3": "^3.15.1"
   "js-yaml@4": "^4.3.1"


### PR DESCRIPTION
## Summary

We moved the Expo and commitlint toolchain onto patched xmldom and fast-uri releases, and releases now only start from pushes to master. This also restores the missing 0.1.4 changelog history.

## Details

- Pins the vulnerable xmldom ranges to 0.8.15 and 0.9.12, and fast-uri to 3.1.6, clearing six Dependabot alerts.
- Removes the manual release dispatch so publishing code and secrets stay on master.
- Drops the stale fast-uri 3.1.5 release-age exception.
- Backfills the 0.1.4 changelog section and fixes the 0.2.0 comparison range.

## Testing steps

1. Install the workspace:

```sh
corepack pnpm install --frozen-lockfile
```

The install should finish successfully with no dependency changes.

2. Run the project checks:

```sh
pnpm test
pnpm run build
pnpm run lint
pnpm run format
pnpm run typecheck
pnpm --filter react-native-magic-toast-example run typecheck
pnpm run changelog:check
actionlint
```

Every command should exit successfully.

3. Run `pnpm audit --prod --json`. It should report no active advisories.
